### PR TITLE
Gallery Images, Admin Page Filter selection, Search Dialog

### DIFF
--- a/faulkner_footsteps/lib/app_state.dart
+++ b/faulkner_footsteps/lib/app_state.dart
@@ -68,22 +68,14 @@ class ApplicationState extends ChangeNotifier {
             //TODO: ensure that all sitefilters have a if statement here
 
             List<siteFilter> filters = [];
-            // print("reached!");
+
             for (String filter
                 in List<String>.from(document.data()["filters"])) {
-              // print("Filter: $filter");
-              if (filter.toLowerCase() == "monument")
-                filters.add(siteFilter.Monument);
-              else if (filter.toLowerCase() == "park") {
-                filters.add(siteFilter.Park);
-              } else if (filter.toLowerCase() == "hall") {
-                filters.add(siteFilter.Hall);
-              } else if (filter.toLowerCase() == "other") {
-                filters.add(siteFilter.Other);
-              } else {
-                print(
-                    "Filter not found in siteFilter enum list. Filter: $filter");
-              }
+              filters.add(siteFilter.values.firstWhere((element) {
+                print("STRING NAME: $filter");
+                print("TEST FILTER NAME: ${element.name}");
+                return element.name == filter;
+              }));
             }
             HistSite site = HistSite(
               name: document.data()["name"] as String,
@@ -177,19 +169,11 @@ class ApplicationState extends ChangeNotifier {
     // }
 
     // we need to convert all the filters to strings so they are firestore friendly
+
     List<String> firebaseFriendlyFilterList = [];
 
     for (siteFilter filter in newSite.filters) {
-      if (filter == siteFilter.Hall) {
-        firebaseFriendlyFilterList.add("Hall");
-      } else if (filter == siteFilter.Monument) {
-        firebaseFriendlyFilterList.add("Monument");
-      } else if (filter == siteFilter.Park) {
-        firebaseFriendlyFilterList.add("Park");
-      } else if (filter == siteFilter.Other) {
-        firebaseFriendlyFilterList.add("Other");
-      }
-      //TODO: add all other filter types as they are added...
+      firebaseFriendlyFilterList.add(filter.name);
     }
 
     var data = {

--- a/faulkner_footsteps/lib/app_state.dart
+++ b/faulkner_footsteps/lib/app_state.dart
@@ -56,6 +56,7 @@ class ApplicationState extends ChangeNotifier {
 
         // Load filters
         await loadFilters();
+        _siteFilters.add(SiteFilter(name: "Other")); //add other site filter
 
         // Site Subscription
 
@@ -78,7 +79,7 @@ class ApplicationState extends ChangeNotifier {
 
             for (String filter
                 in List<String>.from(document.data()["filters"])) {
-              filters.add(SiteFilter.values.firstWhere((element) {
+              filters.add(_siteFilters.firstWhere((element) {
                 print("STRING NAME: $filter");
                 print("TEST FILTER NAME: ${element.name}");
                 return element.name == filter;
@@ -295,7 +296,7 @@ class ApplicationState extends ChangeNotifier {
     }
   }
 
-  //new stuff
+  //new stuff TODO: answer comments. do some research on this
   Future<void> loadFilters() async {
     if (!_loggedIn) return;
 
@@ -306,12 +307,14 @@ class ApplicationState extends ChangeNotifier {
       //is this try needed?
       final documents = await FirebaseFirestore.instance
           .collection("filters")
-          .snapshots()
+          .snapshots() //is the snapshot needed?
           .listen((snapshot) async {
+        //is the listen needed?
         for (final document in snapshot.docs) {
           String name = document.get("name");
           SiteFilter f = new SiteFilter(name: name);
           _siteFilters.add(f);
+          print("filter added: $name");
         }
       });
     } catch (e) {

--- a/faulkner_footsteps/lib/app_state.dart
+++ b/faulkner_footsteps/lib/app_state.dart
@@ -56,7 +56,6 @@ class ApplicationState extends ChangeNotifier {
 
         // Load filters
         await loadFilters();
-        _siteFilters.add(SiteFilter(name: "Other")); //add other site filter
 
         // Site Subscription
 
@@ -305,24 +304,30 @@ class ApplicationState extends ChangeNotifier {
 
     try {
       //is this try needed?
-      final documents = await FirebaseFirestore.instance
-          .collection("filters")
-          .snapshots() //is the snapshot needed?
-          .listen((snapshot) async {
-        //is the listen needed?
-        for (final document in snapshot.docs) {
-          String name = document.get("name");
-          SiteFilter f = new SiteFilter(name: name);
-          _siteFilters.add(f);
-          print("filter added: $name");
-          // if (!_siteFilters.isEmpty &&
-          //     _siteFilters.contains(siteFilters
-          //         .firstWhere((test) => test.name.contains("Other")))) {
-          //   _siteFilters.add(SiteFilter(name: "Other")); //add other site filter
-          // }
-        }
-      });
-    } catch (e) {
+      final snapshot =
+          await FirebaseFirestore.instance.collection("filters").get();
+      for (final document in snapshot.docs) {
+        String name = document.get("name");
+        SiteFilter f = new SiteFilter(name: name);
+        _siteFilters.add(f);
+        print("filter added: $name");
+        // if (!_siteFilters.isEmpty &&
+        //     _siteFilters.contains(siteFilters
+        //         .firstWhere((test) => test.name.contains("Other")))) {
+        //   _siteFilters.add(SiteFilter(name: "Other")); //add other site filter
+        // }
+      }
+      if (!_siteFilters.any((f) => f.name == "Other")) {
+        _siteFilters.add(SiteFilter(name: "Other"));
+      }
+    }
+    // SiteFilter other = _siteFilters.elementAt(0);
+    // SiteFilter last = _siteFilters.last;
+
+    // _siteFilters.removeLast();
+    // _siteFilters.add(other);
+    // _siteFilters[0] = last;
+    catch (e) {
       print("Error loading filters: $e");
     }
   }

--- a/faulkner_footsteps/lib/app_state.dart
+++ b/faulkner_footsteps/lib/app_state.dart
@@ -315,6 +315,11 @@ class ApplicationState extends ChangeNotifier {
           SiteFilter f = new SiteFilter(name: name);
           _siteFilters.add(f);
           print("filter added: $name");
+          // if (!_siteFilters.isEmpty &&
+          //     _siteFilters.contains(siteFilters
+          //         .firstWhere((test) => test.name.contains("Other")))) {
+          //   _siteFilters.add(SiteFilter(name: "Other")); //add other site filter
+          // }
         }
       });
     } catch (e) {

--- a/faulkner_footsteps/lib/dialogs/filter_Dialog.dart
+++ b/faulkner_footsteps/lib/dialogs/filter_Dialog.dart
@@ -1,91 +1,92 @@
-import 'package:faulkner_footsteps/app_state.dart';
-import 'package:faulkner_footsteps/objects/hist_site.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_rating/flutter_rating.dart';
-import 'package:google_fonts/google_fonts.dart';
+// import 'package:faulkner_footsteps/app_state.dart';
+// import 'package:faulkner_footsteps/objects/hist_site.dart';
+// import 'package:faulkner_footsteps/objects/site_filter.dart';
+// import 'package:flutter/material.dart';
+// import 'package:flutter_rating/flutter_rating.dart';
+// import 'package:google_fonts/google_fonts.dart';
 
-enum siteFilter { Monument, Park, Hall, Other }
+// // enum siteFilter { Monument, Park, Hall, Other }
 
-class FilterDialog extends StatefulWidget {
-  const FilterDialog(
-      {super.key, required this.activeFilters, required this.onFiltersChanged});
+// class FilterDialog extends StatefulWidget {
+//   const FilterDialog(
+//       {super.key, required this.activeFilters, required this.onFiltersChanged});
 
-  final List<siteFilter> activeFilters;
+//   final List<SiteFilter> activeFilters;
 
-  final Function onFiltersChanged;
+//   final Function onFiltersChanged;
 
-  @override
-  _FilterDialogState createState() => _FilterDialogState();
-}
+//   @override
+//   _FilterDialogState createState() => _FilterDialogState();
+// }
 
-class _FilterDialogState extends State<FilterDialog> {
-  List<siteFilter> filters = [];
+// class _FilterDialogState extends State<FilterDialog> {
+//   List<SiteFilter> filters = [];
 
-  void initState() {
-    super.initState();
+//   void initState() {
+//     super.initState();
 
-    filters.addAll(widget.activeFilters);
-  }
+//     filters.addAll(widget.activeFilters);
+//   }
 
-  @override
-  Widget build(BuildContext build) {
-    return AlertDialog(
-      alignment: Alignment.topCenter,
-      backgroundColor: const Color.fromARGB(255, 168, 124, 124),
-      title: Text(
-        'Select your filters',
-        style: GoogleFonts.rakkas(
-            textStyle: const TextStyle(
-                color: Color.fromARGB(255, 62, 50, 50), fontSize: 20.0)),
-      ),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Container(
-              child: Wrap(
-            children: siteFilter.values.map((siteFilter site) {
-              return FilterChip(
-                label: Text(site.name),
-                selected: filters.contains(site),
-                onSelected: (bool selected) {
-                  setState(() {
-                    if (selected) {
-                      filters.add(site);
-                    } else {
-                      filters.remove(site);
-                    }
-                  });
-                },
-              );
-            }).toList(),
-          ))
-        ],
-      ),
-      actions: [
-        TextButton(
-          onPressed: () {
-            Navigator.of(context).pop();
-          },
-          child: Text(
-            "Cancel",
-            style: GoogleFonts.rakkas(
-                textStyle: const TextStyle(
-                    color: Color.fromARGB(255, 62, 50, 50), fontSize: 20.0)),
-          ),
-        ),
-        TextButton(
-          onPressed: () {
-            widget.onFiltersChanged(filters);
-            Navigator.of(context).pop();
-          },
-          child: Text(
-            "Submit",
-            style: GoogleFonts.rakkas(
-                textStyle: const TextStyle(
-                    color: Color.fromARGB(255, 62, 50, 50), fontSize: 20.0)),
-          ),
-        ),
-      ],
-    );
-  }
-}
+//   @override
+//   Widget build(BuildContext build) {
+//     return AlertDialog(
+//       alignment: Alignment.topCenter,
+//       backgroundColor: const Color.fromARGB(255, 168, 124, 124),
+//       title: Text(
+//         'Select your filters',
+//         style: GoogleFonts.rakkas(
+//             textStyle: const TextStyle(
+//                 color: Color.fromARGB(255, 62, 50, 50), fontSize: 20.0)),
+//       ),
+//       content: Column(
+//         mainAxisSize: MainAxisSize.min,
+//         children: [
+//           Container(
+//               child: Wrap(
+//             children: siteFilter.values.map((siteFilter site) {
+//               return FilterChip(
+//                 label: Text(site.name),
+//                 selected: filters.contains(site),
+//                 onSelected: (bool selected) {
+//                   setState(() {
+//                     if (selected) {
+//                       filters.add(site);
+//                     } else {
+//                       filters.remove(site);
+//                     }
+//                   });
+//                 },
+//               );
+//             }).toList(),
+//           ))
+//         ],
+//       ),
+//       actions: [
+//         TextButton(
+//           onPressed: () {
+//             Navigator.of(context).pop();
+//           },
+//           child: Text(
+//             "Cancel",
+//             style: GoogleFonts.rakkas(
+//                 textStyle: const TextStyle(
+//                     color: Color.fromARGB(255, 62, 50, 50), fontSize: 20.0)),
+//           ),
+//         ),
+//         TextButton(
+//           onPressed: () {
+//             widget.onFiltersChanged(filters);
+//             Navigator.of(context).pop();
+//           },
+//           child: Text(
+//             "Submit",
+//             style: GoogleFonts.rakkas(
+//                 textStyle: const TextStyle(
+//                     color: Color.fromARGB(255, 62, 50, 50), fontSize: 20.0)),
+//           ),
+//         ),
+//       ],
+//     );
+//   }
+// }

--- a/faulkner_footsteps/lib/objects/hist_site.dart
+++ b/faulkner_footsteps/lib/objects/hist_site.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:faulkner_footsteps/dialogs/filter_Dialog.dart';
+import 'package:faulkner_footsteps/objects/site_filter.dart';
 import 'package:flutter/material.dart';
 
 import 'package:faulkner_footsteps/objects/info_text.dart';
@@ -28,7 +29,7 @@ class HistSite {
   int ratingAmount;
   double lat;
   double lng;
-  List<siteFilter> filters;
+  List<SiteFilter> filters;
 
   void updateImage(List<Uint8List?> images) {
     this.images = images;

--- a/faulkner_footsteps/lib/objects/list_item.dart
+++ b/faulkner_footsteps/lib/objects/list_item.dart
@@ -69,6 +69,7 @@ class ListItem extends StatelessWidget {
                     builder: (context, snapshot) {
                       if (siteInfo.images.length > 0 &&
                           siteInfo.images[0] != null) {
+                        print("List item if statement executed");
                         return Image.memory(
                           siteInfo.images.first!,
                           height: 400,
@@ -78,6 +79,7 @@ class ListItem extends StatelessWidget {
                       } else if (snapshot.connectionState ==
                               ConnectionState.done &&
                           snapshot.data != null) {
+                        print("List item else if statement reached");
                         return Image.memory(
                           snapshot.data!,
                           height: 400,
@@ -85,6 +87,7 @@ class ListItem extends StatelessWidget {
                           fit: BoxFit.cover,
                         );
                       } else {
+                        print("List item else statement reached");
                         return Image.asset(
                           'assets/images/faulkner_thumbnail.png',
                           height: 400,

--- a/faulkner_footsteps/lib/objects/list_item.dart
+++ b/faulkner_footsteps/lib/objects/list_item.dart
@@ -86,6 +86,35 @@ class ListItem extends StatelessWidget {
                           width: double.infinity,
                           fit: BoxFit.cover,
                         );
+                      } else if (snapshot.connectionState ==
+                              ConnectionState.active &&
+                          siteInfo.images.length > 0 &&
+                          siteInfo.images[0] != null) {
+                        print("Stream is still open, image displayed");
+                        return Image.memory(
+                          siteInfo.images.first!,
+                          height: 400,
+                          width: double.infinity,
+                          fit: BoxFit.cover,
+                        );
+                      } else if (snapshot.connectionState ==
+                          ConnectionState.active) {
+                        print("Connection state is active");
+                        return Image.memory(
+                          siteInfo.images.first!,
+                          height: 400,
+                          width: double.infinity,
+                          fit: BoxFit.cover,
+                        );
+                      } else if (snapshot.connectionState ==
+                          ConnectionState.waiting) {
+                        print("Loading cirlce showing");
+                        return Center(
+                            child: Container(
+                                child: CircularProgressIndicator(),
+                                width: double.infinity,
+                                height: 400,
+                                color: Color.fromARGB(255, 107, 79, 79)));
                       } else {
                         print("List item else statement reached");
                         return Image.asset(

--- a/faulkner_footsteps/lib/objects/site_filter.dart
+++ b/faulkner_footsteps/lib/objects/site_filter.dart
@@ -1,0 +1,4 @@
+class SiteFilter {
+  SiteFilter({required this.name});
+  String name;
+}

--- a/faulkner_footsteps/lib/pages/admin_page.dart
+++ b/faulkner_footsteps/lib/pages/admin_page.dart
@@ -221,6 +221,14 @@ class _AdminListPageState extends State<AdminListPage> {
                     ],
 
                     MenuAnchor(
+                        style: MenuStyle(
+                            backgroundColor: WidgetStatePropertyAll(
+                                const Color.fromARGB(255, 238, 214, 196)),
+                            side: WidgetStatePropertyAll(BorderSide(
+                                color: Color.fromARGB(255, 72, 52, 52),
+                                width: 2.0)),
+                            shape: WidgetStatePropertyAll(RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(20.0)))),
                         builder: (BuildContext context,
                             MenuController controller, Widget? child) {
                           return ElevatedButton(
@@ -240,6 +248,11 @@ class _AdminListPageState extends State<AdminListPage> {
                         },
                         menuChildren: acceptableFilters
                             .map((filter) => CheckboxMenuButton(
+                                style: ButtonStyle(
+                                    textStyle: WidgetStatePropertyAll(TextStyle(
+                                        color: Color.fromARGB(255, 72, 52, 52),
+                                        fontSize: 16.0,
+                                        fontWeight: FontWeight.bold))),
                                 closeOnActivate: false,
                                 value: chosenFilters.contains(filter),
                                 onChanged: (bool? value) {
@@ -253,8 +266,8 @@ class _AdminListPageState extends State<AdminListPage> {
                                     }
                                   });
                                 },
-                                child: Text((filter.toString())
-                                    .replaceAll("siteFilter.", ""))))
+                                child:
+                                    Text((filter.toString()).replaceAll("siteFilter.", ""))))
                             .toList()
 
                         // [

--- a/faulkner_footsteps/lib/pages/admin_page.dart
+++ b/faulkner_footsteps/lib/pages/admin_page.dart
@@ -30,11 +30,15 @@ class _AdminListPageState extends State<AdminListPage> {
   final storage = FirebaseStorage.instance;
   final storageRef = FirebaseStorage.instance.ref();
   var uuid = Uuid();
+  List<siteFilter> chosenFilters = [];
+  List<siteFilter> acceptableFilters = [];
 
   @override
   void initState() {
     super.initState();
     updateTimer = Timer.periodic(const Duration(milliseconds: 500), _update);
+    acceptableFilters.addAll(siteFilter.values);
+    acceptableFilters.remove(siteFilter.Other);
   }
 
   void _update(Timer timer) {
@@ -119,8 +123,6 @@ class _AdminListPageState extends State<AdminListPage> {
       });
     }
   }
-
-  List<siteFilter> chosenFilters = [];
 
   Future<void> _showAddSiteDialog() async {
     final nameController = TextEditingController();
@@ -217,6 +219,53 @@ class _AdminListPageState extends State<AdminListPage> {
                               ))
                           .toList(),
                     ],
+
+                    MenuAnchor(
+                        builder: (BuildContext context,
+                            MenuController controller, Widget? child) {
+                          return ElevatedButton(
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor:
+                                    const Color.fromARGB(255, 218, 186, 130),
+                              ),
+                              // focusNode: _buttonFocusNode,
+                              onPressed: () {
+                                if (controller.isOpen) {
+                                  controller.close();
+                                } else {
+                                  controller.open();
+                                }
+                              },
+                              child: const Text("Add Filters"));
+                        },
+                        menuChildren: acceptableFilters
+                            .map((filter) => CheckboxMenuButton(
+                                closeOnActivate: false,
+                                value: chosenFilters.contains(filter),
+                                onChanged: (bool? value) {
+                                  setState(() {
+                                    if (!chosenFilters.contains(filter)) {
+                                      chosenFilters.add(filter);
+                                      print(chosenFilters);
+                                    } else {
+                                      chosenFilters.remove(filter);
+                                      print(chosenFilters);
+                                    }
+                                  });
+                                },
+                                child: Text((filter.toString())
+                                    .replaceAll("siteFilter.", ""))))
+                            .toList()
+
+                        // [
+                        //   CheckboxMenuButton(
+                        //       value: false,
+                        //       onChanged: (bool? value) {
+                        //         print("changed");
+                        //       },
+                        //       child: const Text("Message"))
+                        // ]
+                        ),
                     ElevatedButton(
                       style: ElevatedButton.styleFrom(
                         backgroundColor:

--- a/faulkner_footsteps/lib/pages/admin_page.dart
+++ b/faulkner_footsteps/lib/pages/admin_page.dart
@@ -40,6 +40,7 @@ class _AdminListPageState extends State<AdminListPage> {
     updateTimer = Timer.periodic(const Duration(milliseconds: 500), _update);
     // acceptableFilters.addAll(siteFilter.values);
     // acceptableFilters.remove(siteFilter.Other);
+    acceptableFilters = widget.app_state.siteFilters;
   }
 
   void _update(Timer timer) {
@@ -228,8 +229,10 @@ class _AdminListPageState extends State<AdminListPage> {
                             side: WidgetStatePropertyAll(BorderSide(
                                 color: Color.fromARGB(255, 72, 52, 52),
                                 width: 2.0)),
-                            shape: WidgetStatePropertyAll(RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(20.0)))),
+                            shape: WidgetStatePropertyAll(
+                                RoundedRectangleBorder(
+                                    borderRadius:
+                                        BorderRadius.circular(20.0)))),
                         builder: (BuildContext context,
                             MenuController controller, Widget? child) {
                           return ElevatedButton(
@@ -267,8 +270,7 @@ class _AdminListPageState extends State<AdminListPage> {
                                     }
                                   });
                                 },
-                                child:
-                                    Text((filter.toString()).replaceAll("siteFilter.", ""))))
+                                child: Text((filter.name))))
                             .toList()
 
                         // [

--- a/faulkner_footsteps/lib/pages/admin_page.dart
+++ b/faulkner_footsteps/lib/pages/admin_page.dart
@@ -5,6 +5,7 @@ import 'package:faulkner_footsteps/app_state.dart';
 import 'package:faulkner_footsteps/dialogs/filter_Dialog.dart';
 import 'package:faulkner_footsteps/objects/hist_site.dart';
 import 'package:faulkner_footsteps/objects/info_text.dart';
+import 'package:faulkner_footsteps/objects/site_filter.dart';
 import 'package:faulkner_footsteps/pages/map_display.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter/material.dart';
@@ -30,15 +31,15 @@ class _AdminListPageState extends State<AdminListPage> {
   final storage = FirebaseStorage.instance;
   final storageRef = FirebaseStorage.instance.ref();
   var uuid = Uuid();
-  List<siteFilter> chosenFilters = [];
-  List<siteFilter> acceptableFilters = [];
+  List<SiteFilter> chosenFilters = [];
+  List<SiteFilter> acceptableFilters = [];
 
   @override
   void initState() {
     super.initState();
     updateTimer = Timer.periodic(const Duration(milliseconds: 500), _update);
-    acceptableFilters.addAll(siteFilter.values);
-    acceptableFilters.remove(siteFilter.Other);
+    // acceptableFilters.addAll(siteFilter.values);
+    // acceptableFilters.remove(siteFilter.Other);
   }
 
   void _update(Timer timer) {
@@ -353,7 +354,7 @@ class _AdminListPageState extends State<AdminListPage> {
                   ),
                   onPressed: () async {
                     if (chosenFilters.isEmpty) {
-                      chosenFilters.add(siteFilter.Other);
+                      chosenFilters.add(SiteFilter(name: "Other"));
                     }
                     //I think putting an async here is fine.
                     if (nameController.text.isNotEmpty &&

--- a/faulkner_footsteps/lib/pages/hist_site_page.dart
+++ b/faulkner_footsteps/lib/pages/hist_site_page.dart
@@ -240,7 +240,12 @@ class _HistSitePage extends State<HistSitePage> {
                             future: widget.app_state
                                 .getImage(widget.histSite.imageUrls[index]),
                             builder: (context, snapshot) {
-                              if (snapshot.connectionState ==
+                              if (widget.histSite.images.length > 0 &&
+                                  widget.histSite.images[0] != null) {
+                                return Image.memory(
+                                    widget.histSite.images[index]!,
+                                    fit: BoxFit.cover);
+                              } else if (snapshot.connectionState ==
                                   ConnectionState.waiting) {
                                 return Center(
                                     child: CircularProgressIndicator());

--- a/faulkner_footsteps/lib/pages/hist_site_page.dart
+++ b/faulkner_footsteps/lib/pages/hist_site_page.dart
@@ -222,52 +222,47 @@ class _HistSitePage extends State<HistSitePage> {
                         SwipeImageGallery(
                           context: context,
                           itemBuilder: (context, galleryIndex) {
-                            return FutureBuilder<Uint8List?>(
-                              future: widget.app_state
-                                  .getImage(widget.histSite.imageUrls.first),
-                              builder: (context, snapshot) {
-                                if (widget.histSite.images.length > 0 &&
-                                    widget.histSite.images[0] != null) {
-                                  return Image.memory(
-                                    widget.histSite.images.first!,
-                                    height: 400,
-                                    width: double.infinity,
-                                    fit: BoxFit.cover,
-                                  );
-                                } else if (snapshot.connectionState ==
-                                        ConnectionState.done &&
-                                    snapshot.data != null) {
-                                  return Image.memory(
-                                    snapshot.data!,
-                                    height: 400,
-                                    width: double.infinity,
-                                    fit: BoxFit.cover,
-                                  );
-                                } else {
-                                  return Image.asset(
-                                    'assets/images/faulkner_thumbnail.png',
-                                    height: 400,
-                                    width: double.infinity,
-                                    fit: BoxFit.cover,
-                                  );
-                                }
-                              },
-                            );
+                            return widget.histSite.images[galleryIndex] != null
+                                ? Image.memory(
+                                    widget.histSite.images[galleryIndex]!,
+                                    fit: BoxFit.contain,
+                                  )
+                                : Image.asset(
+                                    "assets/images/faulkner_thumbnail.png",
+                                    fit: BoxFit.contain);
                           },
                           itemCount: widget.histSite.images.length,
                         ).show();
                       },
                       child: Padding(
-                        padding: const EdgeInsets.all(8.0),
-                        child: widget.histSite.images[index] != null
-                            ? Image.memory(
-                                widget.histSite.images[index]!,
-                                fit: BoxFit.contain,
-                              )
-                            : Image.asset(
-                                "assets/images/faulkner_thumbnail.png",
-                                fit: BoxFit.contain),
-                      ),
+                          padding: const EdgeInsets.all(8.0),
+                          child:
+                              //TODO: These should be future builders as well!!!
+                              FutureBuilder<Uint8List?>(
+                            future: widget.app_state
+                                .getImage(widget.histSite.imageUrls.first),
+                            builder: (context, snapshot) {
+                              if (widget.histSite.images.length > 0 &&
+                                  widget.histSite.images[index] != null) {
+                                return Image.memory(
+                                  widget.histSite.images[index]!,
+                                  fit: BoxFit.cover,
+                                );
+                              } else if (snapshot.connectionState ==
+                                      ConnectionState.done &&
+                                  snapshot.data != null) {
+                                return Image.memory(
+                                  snapshot.data!,
+                                  fit: BoxFit.cover,
+                                );
+                              } else {
+                                return Image.asset(
+                                  'assets/images/faulkner_thumbnail.png',
+                                  fit: BoxFit.cover,
+                                );
+                              }
+                            },
+                          )),
                     );
                   },
                 ),

--- a/faulkner_footsteps/lib/pages/hist_site_page.dart
+++ b/faulkner_footsteps/lib/pages/hist_site_page.dart
@@ -236,30 +236,23 @@ class _HistSitePage extends State<HistSitePage> {
                       },
                       child: Padding(
                           padding: const EdgeInsets.all(8.0),
-                          child:
-                              //TODO: These should be future builders as well!!!
-                              FutureBuilder<Uint8List?>(
+                          child: FutureBuilder<Uint8List?>(
                             future: widget.app_state
-                                .getImage(widget.histSite.imageUrls.first),
+                                .getImage(widget.histSite.imageUrls[index]),
                             builder: (context, snapshot) {
-                              if (widget.histSite.images.length > 0 &&
-                                  widget.histSite.images[index] != null) {
-                                return Image.memory(
-                                  widget.histSite.images[index]!,
-                                  fit: BoxFit.cover,
-                                );
-                              } else if (snapshot.connectionState ==
-                                      ConnectionState.done &&
-                                  snapshot.data != null) {
-                                return Image.memory(
-                                  snapshot.data!,
-                                  fit: BoxFit.cover,
-                                );
-                              } else {
+                              if (snapshot.connectionState ==
+                                  ConnectionState.waiting) {
+                                return Center(
+                                    child: CircularProgressIndicator());
+                              } else if (snapshot.hasError ||
+                                  !snapshot.hasData) {
                                 return Image.asset(
                                   'assets/images/faulkner_thumbnail.png',
                                   fit: BoxFit.cover,
                                 );
+                              } else {
+                                return Image.memory(snapshot.data!,
+                                    fit: BoxFit.cover);
                               }
                             },
                           )),

--- a/faulkner_footsteps/lib/pages/list_page.dart
+++ b/faulkner_footsteps/lib/pages/list_page.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:faulkner_footsteps/app_state.dart';
 import 'package:faulkner_footsteps/dialogs/filter_Dialog.dart';
 import 'package:faulkner_footsteps/objects/hist_site.dart';
+import 'package:faulkner_footsteps/objects/site_filter.dart';
 import 'package:faulkner_footsteps/pages/achievement.dart';
 import 'package:faulkner_footsteps/pages/map_display.dart';
 import 'package:faulkner_footsteps/widgets/logout_button.dart';
@@ -79,7 +80,7 @@ class _ListPageState extends State<ListPage> {
   late Map<String, LatLng> siteLocations;
   late Map<String, double> siteDistances;
   late var sorted;
-  late List<siteFilter> activeFilters = [];
+  late List<SiteFilter> activeFilters = [];
   late List<HistSite> searchSites;
 
   @override
@@ -88,7 +89,8 @@ class _ListPageState extends State<ListPage> {
     updateTimer = Timer.periodic(const Duration(milliseconds: 1000), _update);
     displaySites = widget.app_state.historicalSites;
     fullSiteList = widget.app_state.historicalSites;
-    activeFilters.addAll(siteFilter.values);
+    activeFilters.addAll(widget.app_state
+        .siteFilters); //I suspect that this doesn't load quickly enough and that is why active filters starts empty
     searchSites = fullSiteList;
     // print("INIT STATE");
 
@@ -132,10 +134,11 @@ class _ListPageState extends State<ListPage> {
                   height: MediaQuery.of(context).size.height / 9,
                   child: Stack(children: [
                     ListView.builder(
-                      itemCount: siteFilter.values.length,
+                      itemCount: widget.app_state.siteFilters.length,
                       scrollDirection: Axis.horizontal,
                       itemBuilder: (context, index) {
-                        siteFilter currentFilter = siteFilter.values[index];
+                        SiteFilter currentFilter =
+                            widget.app_state.siteFilters[index];
                         return Padding(
                           padding: EdgeInsets.fromLTRB(8, 32, 8, 16),
                           // padding: EdgeInsets.all(8),
@@ -255,6 +258,16 @@ class _ListPageState extends State<ListPage> {
     if (fullSiteList.isEmpty) {
       fullSiteList = widget.app_state.historicalSites;
       displaySites.addAll(fullSiteList);
+      widget.app_state.siteFilters.remove(widget.app_state.siteFilters
+          .firstWhere((test) => test.name.contains("Other")));
+      /*
+        The "other" filter is added so that all the sites marked as other will still be added to the app when it loads. 
+        I am removing it and re-adding it so that the other filter appears last. 
+        This makes sense to me and it really bothers me when the "other" filter shows up first 
+      */
+      widget.app_state.siteFilters.add(SiteFilter(name: "Other"));
+      activeFilters.addAll(widget.app_state.siteFilters);
+
       print("Full Site List: $fullSiteList");
       print("Display Sites: $displaySites");
     }
@@ -272,7 +285,7 @@ class _ListPageState extends State<ListPage> {
     //TODO: set display items so that only items with the filter will appear in display items list
 
     for (HistSite site in displaySites) {
-      for (siteFilter filter in activeFilters) {
+      for (SiteFilter filter in activeFilters) {
         // print("Filter: $filter");
         // print("Site: $site");
         if (site.filters.contains(filter)) {
@@ -288,7 +301,7 @@ class _ListPageState extends State<ListPage> {
     List<HistSite> newDisplaySites = [];
 
     for (HistSite site in searchSites) {
-      for (siteFilter filter in activeFilters) {
+      for (SiteFilter filter in activeFilters) {
         // print("Filter: $filter");
         // print("Site: $site");
         if (site.filters.contains(filter)) {

--- a/faulkner_footsteps/lib/pages/list_page.dart
+++ b/faulkner_footsteps/lib/pages/list_page.dart
@@ -336,11 +336,26 @@ class _ListPageState extends State<ListPage> {
                     color: Color.fromARGB(255, 72, 52, 52), width: 2.0),
                 viewBackgroundColor: const Color.fromARGB(255, 238, 214, 196),
                 isFullScreen: false,
+                headerTextStyle: TextStyle(
+                    color: Color.fromARGB(255, 72, 52, 52),
+                    fontSize: 16.0,
+                    fontWeight: FontWeight.bold),
                 viewConstraints:
                     BoxConstraints(), //this works for some reason despite having no arguments
                 searchController: _searchController,
                 builder: (context, controller) {
                   return SearchBar(
+                    // hintStyle: WidgetStatePropertyAll(TextStyle(
+                    //     color: Color.fromARGB(255, 72, 52, 52),
+                    //     fontSize: 16.0,
+                    // fontWeight: FontWeight.bold)),
+
+                    side: WidgetStatePropertyAll(BorderSide(
+                        color: Color.fromARGB(255, 72, 52, 52), width: 2.0)),
+                    textStyle: WidgetStatePropertyAll(TextStyle(
+                        color: Color.fromARGB(255, 72, 52, 52),
+                        fontSize: 16.0,
+                        fontWeight: FontWeight.bold)),
                     backgroundColor: WidgetStatePropertyAll(Color.fromARGB(
                         255, 238, 214, 196)), //TODO: This might work?
                     leading: Icon(Icons.search),
@@ -417,7 +432,7 @@ class _ListPageState extends State<ListPage> {
                     return ListTile(
                       titleTextStyle: const TextStyle(
                           color: Color.fromARGB(255, 72, 52, 52),
-                          fontSize: 24.0,
+                          fontSize: 16.0,
                           fontWeight: FontWeight.bold),
                       title: Text(filteredSite.name),
                       onTap: () {

--- a/faulkner_footsteps/lib/pages/list_page.dart
+++ b/faulkner_footsteps/lib/pages/list_page.dart
@@ -79,7 +79,7 @@ class _ListPageState extends State<ListPage> {
   late Map<String, LatLng> siteLocations;
   late Map<String, double> siteDistances;
   late var sorted;
-  late List<siteFilter> activeFilters;
+  late List<siteFilter> activeFilters = [];
   late List<HistSite> searchSites;
 
   @override
@@ -88,12 +88,7 @@ class _ListPageState extends State<ListPage> {
     updateTimer = Timer.periodic(const Duration(milliseconds: 1000), _update);
     displaySites = widget.app_state.historicalSites;
     fullSiteList = widget.app_state.historicalSites;
-    activeFilters = [
-      siteFilter.Hall,
-      siteFilter.Monument,
-      siteFilter.Park,
-      siteFilter.Other
-    ];
+    activeFilters.addAll(siteFilter.values);
     searchSites = fullSiteList;
     // print("INIT STATE");
 

--- a/faulkner_footsteps/lib/pages/list_page.dart
+++ b/faulkner_footsteps/lib/pages/list_page.dart
@@ -258,14 +258,14 @@ class _ListPageState extends State<ListPage> {
     if (fullSiteList.isEmpty) {
       fullSiteList = widget.app_state.historicalSites;
       displaySites.addAll(fullSiteList);
-      widget.app_state.siteFilters.remove(widget.app_state.siteFilters
-          .firstWhere((test) => test.name.contains("Other")));
+      // widget.app_state.siteFilters.remove(widget.app_state.siteFilters
+      //     .firstWhere((test) => test.name.contains("Other")));
       /*
         The "other" filter is added so that all the sites marked as other will still be added to the app when it loads. 
         I am removing it and re-adding it so that the other filter appears last. 
         This makes sense to me and it really bothers me when the "other" filter shows up first 
       */
-      widget.app_state.siteFilters.add(SiteFilter(name: "Other"));
+      // widget.app_state.siteFilters.add(SiteFilter(name: "Other"));
       activeFilters.addAll(widget.app_state.siteFilters);
 
       print("Full Site List: $fullSiteList");

--- a/faulkner_footsteps/lib/pages/list_page.dart
+++ b/faulkner_footsteps/lib/pages/list_page.dart
@@ -319,20 +319,30 @@ class _ListPageState extends State<ListPage> {
         builder: (context) {
           return AlertDialog(
             title: const Text("Search"),
+            titleTextStyle: const TextStyle(
+                color: Color.fromARGB(255, 72, 52, 52),
+                fontSize: 32.0,
+                fontWeight: FontWeight.bold),
             shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(20.0)),
+                borderRadius: BorderRadius.circular(20.0),
+                side: BorderSide(
+                    color: Color.fromARGB(255, 72, 52, 52), width: 2.0)),
             elevation: 8,
             backgroundColor: const Color.fromARGB(255, 238, 214, 196),
             alignment: Alignment.topCenter,
             content: SearchAnchor(
+                dividerColor: Color.fromARGB(255, 72, 52, 52),
+                viewSide: BorderSide(
+                    color: Color.fromARGB(255, 72, 52, 52), width: 2.0),
+                viewBackgroundColor: const Color.fromARGB(255, 238, 214, 196),
                 isFullScreen: false,
                 viewConstraints:
                     BoxConstraints(), //this works for some reason despite having no arguments
                 searchController: _searchController,
                 builder: (context, controller) {
                   return SearchBar(
-                    backgroundColor: WidgetStatePropertyAll(
-                        Color.fromARGB(255, 238, 214, 196)),
+                    backgroundColor: WidgetStatePropertyAll(Color.fromARGB(
+                        255, 238, 214, 196)), //TODO: This might work?
                     leading: Icon(Icons.search),
                     trailing: [
                       IconButton(
@@ -405,6 +415,10 @@ class _ListPageState extends State<ListPage> {
                   // });
                   return filteredItems.map((HistSite filteredSite) {
                     return ListTile(
+                      titleTextStyle: const TextStyle(
+                          color: Color.fromARGB(255, 72, 52, 52),
+                          fontSize: 24.0,
+                          fontWeight: FontWeight.bold),
                       title: Text(filteredSite.name),
                       onTap: () {
                         setState(() {

--- a/faulkner_footsteps/lib/pages/list_page.dart
+++ b/faulkner_footsteps/lib/pages/list_page.dart
@@ -258,19 +258,14 @@ class _ListPageState extends State<ListPage> {
     if (fullSiteList.isEmpty) {
       fullSiteList = widget.app_state.historicalSites;
       displaySites.addAll(fullSiteList);
-      // widget.app_state.siteFilters.remove(widget.app_state.siteFilters
-      //     .firstWhere((test) => test.name.contains("Other")));
-      /*
-        The "other" filter is added so that all the sites marked as other will still be added to the app when it loads. 
-        I am removing it and re-adding it so that the other filter appears last. 
-        This makes sense to me and it really bothers me when the "other" filter shows up first 
-      */
-      // widget.app_state.siteFilters.add(SiteFilter(name: "Other"));
-      activeFilters.addAll(widget.app_state.siteFilters);
 
       print("Full Site List: $fullSiteList");
       print("Display Sites: $displaySites");
+      activeFilters.addAll(widget.app_state.siteFilters);
     }
+    /*
+      I want to put the other filter last, so I remove it from th e
+    */
     searchSites = fullSiteList;
     sortDisplayItems();
 

--- a/faulkner_footsteps/lib/pages/list_page.dart
+++ b/faulkner_footsteps/lib/pages/list_page.dart
@@ -318,98 +318,105 @@ class _ListPageState extends State<ListPage> {
         context: context,
         builder: (context) {
           return AlertDialog(
-              alignment: Alignment.topCenter,
-              title: Text("Search"),
-              content: SearchAnchor(
-                  isFullScreen: false,
-                  viewConstraints:
-                      BoxConstraints(), //this works for some reason despite having no arguments
-                  searchController: _searchController,
-                  builder: (context, controller) {
-                    return SearchBar(
-                      leading: Icon(Icons.search),
-                      trailing: [
-                        IconButton(
-                          icon: Icon(Icons.arrow_right_alt),
-                          onPressed: () {
-                            List<HistSite> lst = [];
-                            lst.addAll(fullSiteList.where((HistSite site) {
-                              return site.name
-                                  .toLowerCase()
-                                  .contains(controller.text.toLowerCase());
-                            }));
-                            setState(() {
-                              searchSites = lst;
-                            });
-                            onDisplaySitesChanged();
-                            Navigator.pop(context);
-                          },
-                        )
-                      ],
-                      controller: _searchController,
-                      onTap: () {
-                        controller.openView();
-                      },
-                      onChanged: (query) {
-                        print("here!");
-                        controller.closeView(query);
-                      },
+            title: const Text("Search"),
+            shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(20.0)),
+            elevation: 8,
+            backgroundColor: const Color.fromARGB(255, 238, 214, 196),
+            alignment: Alignment.topCenter,
+            content: SearchAnchor(
+                isFullScreen: false,
+                viewConstraints:
+                    BoxConstraints(), //this works for some reason despite having no arguments
+                searchController: _searchController,
+                builder: (context, controller) {
+                  return SearchBar(
+                    backgroundColor: WidgetStatePropertyAll(
+                        Color.fromARGB(255, 238, 214, 196)),
+                    leading: Icon(Icons.search),
+                    trailing: [
+                      IconButton(
+                        icon: Icon(Icons.arrow_right_alt),
+                        onPressed: () {
+                          List<HistSite> lst = [];
+                          lst.addAll(fullSiteList.where((HistSite site) {
+                            return site.name
+                                .toLowerCase()
+                                .contains(controller.text.toLowerCase());
+                          }));
+                          setState(() {
+                            searchSites = lst;
+                          });
+                          onDisplaySitesChanged();
+                          Navigator.pop(context);
+                        },
+                      )
+                    ],
+                    controller: _searchController,
+                    onTap: () {
+                      controller.openView();
+                    },
+                    onChanged: (query) {
+                      print("here!");
+                      controller.closeView(query);
+                    },
 
-                      // onChanged: (query) {
-                      //   List<HistSite> lst = [];
-                      //   lst.addAll(fullSiteList.where((HistSite site) {
-                      //     return site.name
-                      //         .toLowerCase()
-                      //         .contains(query.toLowerCase());
-                      //   }));
-                      //   setState(() {
-                      //     displaySites = lst;
-                      //   });
-                      //   Navigator.pop(context);
-                      // },
-                      onSubmitted: (query) {
-                        controller.closeView(query);
-                        List<HistSite> lst = [];
-                        lst.addAll(fullSiteList.where((HistSite site) {
-                          return site.name
-                              .toLowerCase()
-                              .contains(query.toLowerCase());
-                        }));
+                    // onChanged: (query) {
+                    //   List<HistSite> lst = [];
+                    //   lst.addAll(fullSiteList.where((HistSite site) {
+                    //     return site.name
+                    //         .toLowerCase()
+                    //         .contains(query.toLowerCase());
+                    //   }));
+                    //   setState(() {
+                    //     displaySites = lst;
+                    //   });
+                    //   Navigator.pop(context);
+                    // },
+                    onSubmitted: (query) {
+                      controller.closeView(query);
+                      List<HistSite> lst = [];
+                      lst.addAll(fullSiteList.where((HistSite site) {
+                        return site.name
+                            .toLowerCase()
+                            .contains(query.toLowerCase());
+                      }));
+                      setState(() {
+                        searchSites = lst;
+                      });
+                      onDisplaySitesChanged();
+                      Navigator.pop(context);
+                    },
+                  );
+                },
+                suggestionsBuilder: (context, controller) {
+                  final String input = controller.text.toLowerCase();
+                  List<HistSite> filteredItems = [];
+                  for (HistSite site in fullSiteList) {
+                    if (site.name.toLowerCase().contains(input)) {
+                      filteredItems.add(site);
+                    }
+                  }
+                  // return List<ListTile>.generate(filteredItems.length,
+                  //     (int index) {
+                  //   return ListTile(
+                  //     title: Text(filteredItems[index].name),
+                  //   );
+                  // });
+                  return filteredItems.map((HistSite filteredSite) {
+                    return ListTile(
+                      title: Text(filteredSite.name),
+                      onTap: () {
                         setState(() {
-                          searchSites = lst;
+                          displaySites = [filteredSite];
+                          controller.closeView(filteredSite.name);
                         });
-                        onDisplaySitesChanged();
                         Navigator.pop(context);
                       },
                     );
-                  },
-                  suggestionsBuilder: (context, controller) {
-                    final String input = controller.text.toLowerCase();
-                    List<HistSite> filteredItems = [];
-                    for (HistSite site in fullSiteList) {
-                      if (site.name.toLowerCase().contains(input)) {
-                        filteredItems.add(site);
-                      }
-                    }
-                    // return List<ListTile>.generate(filteredItems.length,
-                    //     (int index) {
-                    //   return ListTile(
-                    //     title: Text(filteredItems[index].name),
-                    //   );
-                    // });
-                    return filteredItems.map((HistSite filteredSite) {
-                      return ListTile(
-                        title: Text(filteredSite.name),
-                        onTap: () {
-                          setState(() {
-                            displaySites = [filteredSite];
-                            controller.closeView(filteredSite.name);
-                          });
-                          Navigator.pop(context);
-                        },
-                      );
-                    });
-                  }));
+                  });
+                }),
+          );
         });
   }
 


### PR DESCRIPTION
The bug with the gallery images is now gone. They display the correct pictures and the gallery goes full screen and you can swipe through the  pictures. On the admin page, you can select the filters you want when creating a new historical site. These filters are uploaded to the firebase as appropriate strings. I got rid of all the if statements for each filter in the appstate - I found a better way to handle all of that stuff. The search dialog is now updated to match the style of the rest of the app. However, I am not the best at design so we might have to make slight adjustments to it. 

closes #96 
closes #74 
closes #70 