### PR TITLE
Achievements v2

### DIFF
--- a/faulkner_footsteps/ios/Podfile.lock
+++ b/faulkner_footsteps/ios/Podfile.lock
@@ -1371,6 +1371,9 @@ PODS:
     - Flutter
     - FlutterMacOS
   - RecaptchaInterop (100.0.0)
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - url_launcher_ios (0.0.1):
     - Flutter
 
@@ -1388,6 +1391,7 @@ DEPENDENCIES:
   - GoogleMaps (~> 8.0)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 SPEC REPOS:
@@ -1440,6 +1444,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/image_picker_ios/ios"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
+  shared_preferences_foundation:
+    :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
@@ -1478,6 +1484,7 @@ SPEC CHECKSUMS:
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
+  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
   url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
 
 PODFILE CHECKSUM: 27141970d42ea83ea2705ffd782ab81376ddf8a3

--- a/faulkner_footsteps/lib/pages/achievement.dart
+++ b/faulkner_footsteps/lib/pages/achievement.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:faulkner_footsteps/app_state.dart';
+import 'package:google_fonts/google_fonts.dart';
 
 class AchievementsPage extends StatefulWidget {
   AchievementsPage({super.key, required this.displaySites});
@@ -12,7 +13,7 @@ class AchievementsPage extends StatefulWidget {
 }
 
 class AchievementsPageState extends State<AchievementsPage> {
-  // To track visited places
+  // To track visited places - only called from map view
   void visitPlace(BuildContext context, String place) async {
     // If the place is visited for the first time, a popup will appear and update the state
     final appState = Provider.of<ApplicationState>(context, listen: false);
@@ -55,6 +56,164 @@ class AchievementsPageState extends State<AchievementsPage> {
     }
   }
 
+  // New method to show information popup when achievement is tapped
+  void showAchievementInfo(
+      BuildContext context, String placeName, bool isVisited) {
+    showDialog(
+      context: context,
+      builder: (context) => Dialog(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(20.0),
+        ),
+        elevation: 8,
+        backgroundColor: Colors.transparent,
+        child: Container(
+          width: double.infinity,
+          decoration: BoxDecoration(
+            color: const Color.fromARGB(255, 238, 214, 196),
+            borderRadius: BorderRadius.circular(20.0),
+            border: Border.all(
+              color: const Color.fromARGB(255, 107, 79, 79),
+              width: 3.0,
+            ),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withOpacity(0.3),
+                spreadRadius: 2,
+                blurRadius: 10,
+                offset: const Offset(0, 5),
+              ),
+            ],
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              // Header
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 24, 20, 16),
+                child: Text(
+                  placeName,
+                  style: GoogleFonts.ultra(
+                    textStyle: const TextStyle(
+                      color: Color.fromARGB(255, 72, 52, 52),
+                      fontSize: 22.0,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+
+              // Achievement Status
+              Container(
+                padding:
+                    const EdgeInsets.symmetric(vertical: 10, horizontal: 24),
+                margin: const EdgeInsets.symmetric(horizontal: 24),
+                decoration: BoxDecoration(
+                  color: isVisited
+                      ? Colors.green[100]
+                      : const Color.fromARGB(255, 255, 243, 228),
+                  borderRadius: BorderRadius.circular(15),
+                  border: Border.all(
+                    color: isVisited
+                        ? Colors.green
+                        : const Color.fromARGB(255, 107, 79, 79),
+                    width: 2,
+                  ),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      isVisited ? Icons.emoji_events : Icons.place,
+                      size: 24,
+                      color: isVisited
+                          ? Colors.green
+                          : const Color.fromARGB(255, 143, 6, 6),
+                    ),
+                    const SizedBox(width: 10),
+                    Text(
+                      isVisited ? "Completed!" : "Not Visited",
+                      style: GoogleFonts.rakkas(
+                        textStyle: TextStyle(
+                          color: isVisited
+                              ? Colors.green[800]
+                              : const Color.fromARGB(255, 72, 52, 52),
+                          fontSize: 16,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+
+              // Information content
+              Padding(
+                padding: const EdgeInsets.fromLTRB(24, 20, 24, 20),
+                child: Text(
+                  isVisited
+                      ? "You've already discovered this historical site. Great job!"
+                      : "To unlock this achievement, you need to visit this historical site in person. Use the map to find and navigate to this location.",
+                  style: GoogleFonts.rakkas(
+                    textStyle: const TextStyle(
+                      color: Color.fromARGB(255, 107, 79, 79),
+                      fontSize: 16,
+                    ),
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+
+              // Close button
+              Padding(
+                padding: const EdgeInsets.only(bottom: 24, top: 8),
+                child: Container(
+                  width: 120,
+                  height: 44,
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(22),
+                    border: Border.all(
+                      color: const Color.fromARGB(255, 107, 79, 79),
+                      width: 2.0,
+                    ),
+                    color: const Color.fromARGB(255, 255, 243, 228),
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black.withOpacity(0.1),
+                        spreadRadius: 1,
+                        blurRadius: 3,
+                        offset: const Offset(0, 2),
+                      ),
+                    ],
+                  ),
+                  child: Material(
+                    color: Colors.transparent,
+                    child: InkWell(
+                      borderRadius: BorderRadius.circular(22),
+                      onTap: () => Navigator.of(context).pop(),
+                      child: Center(
+                        child: Text(
+                          "Close",
+                          style: GoogleFonts.rakkas(
+                            textStyle: const TextStyle(
+                              color: Color.fromARGB(255, 107, 79, 79),
+                              fontSize: 16,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Consumer<ApplicationState>(
@@ -79,7 +238,8 @@ class AchievementsPageState extends State<AchievementsPage> {
                 final fontSize = place.name.length > 20 ? 14.0 : 16.0;
 
                 return GestureDetector(
-                  onTap: () => visitPlace(context, place.name),
+                  onTap: () =>
+                      showAchievementInfo(context, place.name, isVisited),
                   child: Container(
                     decoration: BoxDecoration(
                       color: isVisited

--- a/faulkner_footsteps/lib/pages/achievement.dart
+++ b/faulkner_footsteps/lib/pages/achievement.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:faulkner_footsteps/app_state.dart';
+import 'package:faulkner_footsteps/dialogs/filter_Dialog.dart';
+import 'package:faulkner_footsteps/objects/hist_site.dart';
 import 'package:google_fonts/google_fonts.dart';
 
 class AchievementsPage extends StatefulWidget {
@@ -12,7 +14,85 @@ class AchievementsPage extends StatefulWidget {
   }
 }
 
+// Class to represent a progress-based achievement
+class ProgressAchievement {
+  final String title;
+  final String description;
+  final List<String> requiredSites;
+  final siteFilter? filterType;
+
+  ProgressAchievement(
+      {required this.title,
+      required this.description,
+      required this.requiredSites,
+      this.filterType});
+
+  // Calculate progress based on visited places
+  double calculateProgress(Set<String> visitedPlaces) {
+    if (requiredSites.isEmpty) return 0.0;
+
+    int completedCount = 0;
+    for (String site in requiredSites) {
+      if (visitedPlaces.contains(site)) {
+        completedCount++;
+      }
+    }
+
+    return completedCount / requiredSites.length;
+  }
+
+  // Check if achievement is completed
+  bool isCompleted(Set<String> visitedPlaces) {
+    return calculateProgress(visitedPlaces) >= 1.0;
+  }
+}
+
 class AchievementsPageState extends State<AchievementsPage> {
+  // Define the progress achievements
+  late List<ProgressAchievement> progressAchievements;
+
+  @override
+  void initState() {
+    super.initState();
+
+    // Initialize progress achievements
+    _initProgressAchievements();
+  }
+
+  void _initProgressAchievements() {
+    progressAchievements = [];
+
+    // Find all sites that are monuments
+    List<String> monuments = [];
+    List<String> hendrixSites = [];
+
+    for (var site in widget.displaySites) {
+      if (site.filters.contains(siteFilter.Monument)) {
+        monuments.add(site.name);
+      }
+
+      // For demonstrative purposes, let's consider sites with "Hendrix" or "Hall" in the name
+      if (site.name.contains("Hendrix") || site.name.contains("Hall")) {
+        hendrixSites.add(site.name);
+      }
+    }
+
+    // Add the monument achievement
+    progressAchievements.add(ProgressAchievement(
+        title: "Monument Explorer",
+        description: "Visit all monument sites",
+        requiredSites: monuments,
+        filterType: siteFilter.Monument));
+
+    // Add the Hendrix sites achievement
+    if (hendrixSites.isNotEmpty) {
+      progressAchievements.add(ProgressAchievement(
+          title: "Hendrix Campus Explorer",
+          description: "Visit all sites at Hendrix",
+          requiredSites: hendrixSites));
+    }
+  }
+
   // To track visited places - only called from map view
   void visitPlace(BuildContext context, String place) async {
     // If the place is visited for the first time, a popup will appear and update the state
@@ -54,6 +134,231 @@ class AchievementsPageState extends State<AchievementsPage> {
         ),
       );
     }
+  }
+
+  // Show information popup for progress achievements
+  void showProgressAchievementInfo(BuildContext context,
+      ProgressAchievement achievement, double progress, bool isCompleted) {
+    showDialog(
+      context: context,
+      builder: (context) => Dialog(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(20.0),
+        ),
+        elevation: 8,
+        backgroundColor: Colors.transparent,
+        child: Container(
+          width: double.infinity,
+          decoration: BoxDecoration(
+            color: const Color.fromARGB(255, 238, 214, 196),
+            borderRadius: BorderRadius.circular(20.0),
+            border: Border.all(
+              color: const Color.fromARGB(255, 107, 79, 79),
+              width: 3.0,
+            ),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withOpacity(0.3),
+                spreadRadius: 2,
+                blurRadius: 10,
+                offset: const Offset(0, 5),
+              ),
+            ],
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              // Header
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 24, 20, 16),
+                child: Text(
+                  achievement.title,
+                  style: GoogleFonts.ultra(
+                    textStyle: const TextStyle(
+                      color: Color.fromARGB(255, 72, 52, 52),
+                      fontSize: 22.0,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+
+              // Achievement description
+              Padding(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
+                child: Text(
+                  achievement.description,
+                  style: GoogleFonts.rakkas(
+                    textStyle: const TextStyle(
+                      color: Color.fromARGB(255, 107, 79, 79),
+                      fontSize: 16,
+                    ),
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+
+              // Achievement Status with progress
+              Padding(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+                child: Column(
+                  children: [
+                    // Progress bar
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(10),
+                      child: LinearProgressIndicator(
+                        value: progress,
+                        minHeight: 20,
+                        backgroundColor:
+                            const Color.fromARGB(255, 255, 243, 228),
+                        color: Colors.green,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    // Progress text
+                    Text(
+                      "${(progress * 100).toInt()}% Complete",
+                      style: GoogleFonts.rakkas(
+                        textStyle: const TextStyle(
+                          color: Color.fromARGB(255, 72, 52, 52),
+                          fontSize: 16,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+
+              // List of required sites
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 24),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      "Required Sites:",
+                      style: GoogleFonts.ultra(
+                        textStyle: const TextStyle(
+                          color: Color.fromARGB(255, 72, 52, 52),
+                          fontSize: 16,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    // Display sites with checkmarks for visited ones
+                    Consumer<ApplicationState>(
+                      builder: (context, appState, _) {
+                        return Column(
+                          children: achievement.requiredSites.map((site) {
+                            bool visited = appState.hasVisited(site);
+                            return Padding(
+                              padding: const EdgeInsets.symmetric(vertical: 4),
+                              child: Row(
+                                children: [
+                                  Icon(
+                                    visited
+                                        ? Icons.check_circle
+                                        : Icons.circle_outlined,
+                                    color: visited
+                                        ? Colors.green
+                                        : const Color.fromARGB(
+                                            255, 107, 79, 79),
+                                    size: 20,
+                                  ),
+                                  const SizedBox(width: 8),
+                                  Expanded(
+                                    child: Text(
+                                      site,
+                                      style: GoogleFonts.rakkas(
+                                        textStyle: TextStyle(
+                                          color: visited
+                                              ? Colors.green[800]
+                                              : const Color.fromARGB(
+                                                  255, 72, 52, 52),
+                                          fontSize: 14,
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            );
+                          }).toList(),
+                        );
+                      },
+                    ),
+                  ],
+                ),
+              ),
+
+              // Information content
+              Padding(
+                padding: const EdgeInsets.fromLTRB(24, 20, 24, 20),
+                child: Text(
+                  isCompleted
+                      ? "Congratulations! You've completed this achievement."
+                      : "Visit all the required sites to complete this achievement.",
+                  style: GoogleFonts.rakkas(
+                    textStyle: const TextStyle(
+                      color: Color.fromARGB(255, 107, 79, 79),
+                      fontSize: 16,
+                    ),
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+
+              // Close button
+              Padding(
+                padding: const EdgeInsets.only(bottom: 24, top: 8),
+                child: Container(
+                  width: 120,
+                  height: 44,
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(22),
+                    border: Border.all(
+                      color: const Color.fromARGB(255, 107, 79, 79),
+                      width: 2.0,
+                    ),
+                    color: const Color.fromARGB(255, 255, 243, 228),
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black.withOpacity(0.1),
+                        spreadRadius: 1,
+                        blurRadius: 3,
+                        offset: const Offset(0, 2),
+                      ),
+                    ],
+                  ),
+                  child: Material(
+                    color: Colors.transparent,
+                    child: InkWell(
+                      borderRadius: BorderRadius.circular(22),
+                      onTap: () => Navigator.of(context).pop(),
+                      child: Center(
+                        child: Text(
+                          "Close",
+                          style: GoogleFonts.rakkas(
+                            textStyle: const TextStyle(
+                              color: Color.fromARGB(255, 107, 79, 79),
+                              fontSize: 16,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 
   // New method to show information popup when achievement is tapped
@@ -220,94 +525,309 @@ class AchievementsPageState extends State<AchievementsPage> {
       builder: (context, appState, _) {
         return Scaffold(
           backgroundColor: const Color.fromARGB(255, 238, 214, 196),
-          body: Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: GridView.builder(
-              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                crossAxisCount: 3,
-                mainAxisSpacing: 10,
-                crossAxisSpacing: 10,
-                mainAxisExtent: 160, // Increased height further
+          appBar: AppBar(
+            leading: BackButton(
+              color: Color.fromARGB(255, 255, 243, 228),
+            ),
+            backgroundColor: const Color.fromARGB(255, 107, 79, 79),
+            elevation: 5.0,
+            title: Text(
+              "Achievements",
+              style: GoogleFonts.ultra(
+                textStyle: const TextStyle(
+                  color: Color.fromARGB(255, 255, 243, 228),
+                ),
               ),
-              itemCount: widget.displaySites.length,
-              itemBuilder: (context, index) {
-                final place = widget.displaySites[index];
-                final isVisited = appState.hasVisited(place.name);
-
-                // Calculate font size based on text length
-                final fontSize = place.name.length > 20 ? 14.0 : 16.0;
-
-                return GestureDetector(
-                  onTap: () =>
-                      showAchievementInfo(context, place.name, isVisited),
-                  child: Container(
-                    decoration: BoxDecoration(
-                      color: isVisited
-                          ? Colors.green[100]
-                          : const Color.fromARGB(255, 255, 243, 228),
-                      borderRadius: BorderRadius.circular(15),
-                      border: Border.all(
-                        color: isVisited
-                            ? Colors.green
-                            : const Color.fromARGB(255, 107, 79, 79),
-                        width: 2,
-                      ),
-                    ),
-                    child: Column(
-                      children: [
-                        // Top section with icon
-                        Padding(
-                          padding: const EdgeInsets.only(top: 15.0),
-                          child: Icon(
-                            isVisited ? Icons.emoji_events : Icons.place,
-                            size: 40,
-                            color: isVisited
-                                ? Colors.green
-                                : const Color.fromARGB(255, 143, 6, 6),
+            ),
+            centerTitle: true,
+          ),
+          body: SingleChildScrollView(
+            child: Padding(
+              padding: const EdgeInsets.all(12.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  // Progress Achievements Section
+                  if (progressAchievements.isNotEmpty) ...[
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 16.0, top: 8.0),
+                      child: Text(
+                        "Progress Achievements",
+                        style: GoogleFonts.ultra(
+                          textStyle: const TextStyle(
+                            color: Color.fromARGB(255, 72, 52, 52),
+                            fontSize: 20.0,
                           ),
                         ),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                    // List of progress achievements
+                    ...progressAchievements.map((achievement) {
+                      double progress =
+                          achievement.calculateProgress(appState.visitedPlaces);
+                      bool isCompleted =
+                          achievement.isCompleted(appState.visitedPlaces);
 
-                        // Middle section with name
-                        Expanded(
-                          child: Padding(
-                            padding: const EdgeInsets.symmetric(
-                                horizontal: 8.0, vertical: 8.0),
-                            child: Center(
-                              child: Text(
-                                place.name,
-                                textAlign: TextAlign.center,
-                                style: TextStyle(
-                                  fontWeight: FontWeight.bold,
-                                  fontSize: fontSize, // Adaptive font size
-                                  color: Color.fromARGB(255, 72, 52, 52),
-                                ),
-                                maxLines: 3, // Increased max lines
-                                overflow: TextOverflow.ellipsis,
+                      return Padding(
+                        padding: const EdgeInsets.only(bottom: 12.0),
+                        child: GestureDetector(
+                          onTap: () => showProgressAchievementInfo(
+                              context, achievement, progress, isCompleted),
+                          child: Container(
+                            decoration: BoxDecoration(
+                              color: const Color.fromARGB(255, 255, 243, 228),
+                              borderRadius: BorderRadius.circular(15),
+                              border: Border.all(
+                                color: isCompleted
+                                    ? Colors.green
+                                    : const Color.fromARGB(255, 107, 79, 79),
+                                width: 2,
                               ),
+                              boxShadow: [
+                                BoxShadow(
+                                  color: Colors.black.withOpacity(0.1),
+                                  spreadRadius: 1,
+                                  blurRadius: 4,
+                                  offset: const Offset(0, 2),
+                                ),
+                              ],
+                            ),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                // Achievement header row
+                                Padding(
+                                  padding:
+                                      const EdgeInsets.fromLTRB(16, 12, 16, 8),
+                                  child: Row(
+                                    children: [
+                                      // Achievement icon
+                                      Container(
+                                        width: 40,
+                                        height: 40,
+                                        decoration: BoxDecoration(
+                                          color: isCompleted
+                                              ? Colors.green[100]
+                                              : Color.fromARGB(
+                                                  255, 238, 214, 196),
+                                          shape: BoxShape.circle,
+                                          border: Border.all(
+                                            color: isCompleted
+                                                ? Colors.green
+                                                : Color.fromARGB(
+                                                    255, 107, 79, 79),
+                                            width: 2,
+                                          ),
+                                        ),
+                                        child: Icon(
+                                          isCompleted
+                                              ? Icons.emoji_events
+                                              : Icons.stars,
+                                          color: isCompleted
+                                              ? Colors.green
+                                              : Color.fromARGB(
+                                                  255, 107, 79, 79),
+                                          size: 24,
+                                        ),
+                                      ),
+                                      SizedBox(width: 12),
+                                      // Achievement title and description
+                                      Expanded(
+                                        child: Column(
+                                          crossAxisAlignment:
+                                              CrossAxisAlignment.start,
+                                          children: [
+                                            Text(
+                                              achievement.title,
+                                              style: GoogleFonts.ultra(
+                                                textStyle: TextStyle(
+                                                  color: Color.fromARGB(
+                                                      255, 72, 52, 52),
+                                                  fontSize: 16,
+                                                  fontWeight: FontWeight.bold,
+                                                ),
+                                              ),
+                                            ),
+                                            SizedBox(height: 2),
+                                            Text(
+                                              achievement.description,
+                                              style: GoogleFonts.rakkas(
+                                                textStyle: TextStyle(
+                                                  color: Color.fromARGB(
+                                                      255, 107, 79, 79),
+                                                  fontSize: 14,
+                                                ),
+                                              ),
+                                            ),
+                                          ],
+                                        ),
+                                      ),
+                                      // Progress percentage
+                                      Text(
+                                        "${(progress * 100).toInt()}%",
+                                        style: GoogleFonts.rakkas(
+                                          textStyle: TextStyle(
+                                            color: isCompleted
+                                                ? Colors.green[800]
+                                                : Color.fromARGB(
+                                                    255, 72, 52, 52),
+                                            fontSize: 16,
+                                            fontWeight: FontWeight.bold,
+                                          ),
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                                // Progress bar
+                                Padding(
+                                  padding:
+                                      const EdgeInsets.fromLTRB(16, 4, 16, 12),
+                                  child: ClipRRect(
+                                    borderRadius: BorderRadius.circular(10),
+                                    child: LinearProgressIndicator(
+                                      value: progress,
+                                      minHeight: 8,
+                                      backgroundColor:
+                                          Color.fromARGB(255, 238, 214, 196),
+                                      color: Colors.green,
+                                    ),
+                                  ),
+                                ),
+                              ],
                             ),
                           ),
                         ),
+                      );
+                    }).toList(),
 
-                        // Bottom section with "Done!" label
-                        Container(
-                          height: 24,
-                          alignment: Alignment.center,
-                          padding: const EdgeInsets.only(bottom: 5.0),
-                          child: isVisited
-                              ? const Text(
-                                  "Done!",
-                                  style: TextStyle(
-                                    color: Colors.green,
-                                    fontWeight: FontWeight.bold,
-                                  ),
-                                )
-                              : const SizedBox(), // Empty placeholder
+                    // Divider between sections
+                    Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 16.0),
+                      child: Divider(
+                        color: Color.fromARGB(255, 107, 79, 79),
+                        thickness: 1.5,
+                      ),
+                    ),
+                  ],
+
+                  // Individual Historical Sites Achievements
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 16.0),
+                    child: Text(
+                      "Historical Sites",
+                      style: GoogleFonts.ultra(
+                        textStyle: const TextStyle(
+                          color: Color.fromARGB(255, 72, 52, 52),
+                          fontSize: 20.0,
                         ),
-                      ],
+                      ),
+                      textAlign: TextAlign.center,
                     ),
                   ),
-                );
-              },
+                  // Grid of individual site achievements
+                  GridView.builder(
+                    shrinkWrap: true,
+                    physics: NeverScrollableScrollPhysics(),
+                    gridDelegate:
+                        const SliverGridDelegateWithFixedCrossAxisCount(
+                      crossAxisCount: 3,
+                      mainAxisSpacing: 10,
+                      crossAxisSpacing: 10,
+                      mainAxisExtent: 160, // Increased height further
+                    ),
+                    itemCount: widget.displaySites.length,
+                    itemBuilder: (context, index) {
+                      final place = widget.displaySites[index];
+                      final isVisited = appState.hasVisited(place.name);
+
+                      // Calculate font size based on text length
+                      final fontSize = place.name.length > 20 ? 14.0 : 16.0;
+
+                      return GestureDetector(
+                        onTap: () =>
+                            showAchievementInfo(context, place.name, isVisited),
+                        child: Container(
+                          decoration: BoxDecoration(
+                            color: isVisited
+                                ? Colors.green[100]
+                                : const Color.fromARGB(255, 255, 243, 228),
+                            borderRadius: BorderRadius.circular(15),
+                            border: Border.all(
+                              color: isVisited
+                                  ? Colors.green
+                                  : const Color.fromARGB(255, 107, 79, 79),
+                              width: 2,
+                            ),
+                            boxShadow: [
+                              BoxShadow(
+                                color: Colors.black.withOpacity(0.1),
+                                spreadRadius: 1,
+                                blurRadius: 3,
+                                offset: const Offset(0, 2),
+                              ),
+                            ],
+                          ),
+                          child: Column(
+                            children: [
+                              // Top section with icon
+                              Padding(
+                                padding: const EdgeInsets.only(top: 15.0),
+                                child: Icon(
+                                  isVisited ? Icons.emoji_events : Icons.place,
+                                  size: 40,
+                                  color: isVisited
+                                      ? Colors.green
+                                      : const Color.fromARGB(255, 143, 6, 6),
+                                ),
+                              ),
+
+                              // Middle section with name
+                              Expanded(
+                                child: Padding(
+                                  padding: const EdgeInsets.symmetric(
+                                      horizontal: 8.0, vertical: 8.0),
+                                  child: Center(
+                                    child: Text(
+                                      place.name,
+                                      textAlign: TextAlign.center,
+                                      style: TextStyle(
+                                        fontWeight: FontWeight.bold,
+                                        fontSize:
+                                            fontSize, // Adaptive font size
+                                        color: Color.fromARGB(255, 72, 52, 52),
+                                      ),
+                                      maxLines: 3, // Increased max lines
+                                      overflow: TextOverflow.ellipsis,
+                                    ),
+                                  ),
+                                ),
+                              ),
+
+                              // Bottom section with "Done!" label
+                              Container(
+                                height: 24,
+                                alignment: Alignment.center,
+                                padding: const EdgeInsets.only(bottom: 5.0),
+                                child: isVisited
+                                    ? const Text(
+                                        "Done!",
+                                        style: TextStyle(
+                                          color: Colors.green,
+                                          fontWeight: FontWeight.bold,
+                                        ),
+                                      )
+                                    : const SizedBox(), // Empty placeholder
+                              ),
+                            ],
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ],
+              ),
             ),
           ),
         );

--- a/faulkner_footsteps/lib/pages/achievement.dart
+++ b/faulkner_footsteps/lib/pages/achievement.dart
@@ -20,27 +20,28 @@ class ProgressAchievement {
   final String description;
   final List<String> requiredSites;
   final siteFilter? filterType;
-
-  ProgressAchievement(
-      {required this.title,
-      required this.description,
-      required this.requiredSites,
-      this.filterType});
-
+  
+  ProgressAchievement({
+    required this.title, 
+    required this.description, 
+    required this.requiredSites,
+    this.filterType
+  });
+  
   // Calculate progress based on visited places
   double calculateProgress(Set<String> visitedPlaces) {
     if (requiredSites.isEmpty) return 0.0;
-
+    
     int completedCount = 0;
     for (String site in requiredSites) {
       if (visitedPlaces.contains(site)) {
         completedCount++;
       }
     }
-
+    
     return completedCount / requiredSites.length;
   }
-
+  
   // Check if achievement is completed
   bool isCompleted(Set<String> visitedPlaces) {
     return calculateProgress(visitedPlaces) >= 1.0;
@@ -50,46 +51,52 @@ class ProgressAchievement {
 class AchievementsPageState extends State<AchievementsPage> {
   // Define the progress achievements
   late List<ProgressAchievement> progressAchievements;
-
+  
   @override
   void initState() {
     super.initState();
-
+    
     // Initialize progress achievements
     _initProgressAchievements();
   }
-
+  
   void _initProgressAchievements() {
     progressAchievements = [];
-
+    
     // Find all sites that are monuments
     List<String> monuments = [];
     List<String> hendrixSites = [];
-
+    
     for (var site in widget.displaySites) {
       if (site.filters.contains(siteFilter.Monument)) {
         monuments.add(site.name);
       }
-
+      
       // For demonstrative purposes, let's consider sites with "Hendrix" or "Hall" in the name
       if (site.name.contains("Hendrix") || site.name.contains("Hall")) {
         hendrixSites.add(site.name);
       }
     }
-
+    
     // Add the monument achievement
-    progressAchievements.add(ProgressAchievement(
+    progressAchievements.add(
+      ProgressAchievement(
         title: "Monument Explorer",
         description: "Visit all monument sites",
         requiredSites: monuments,
-        filterType: siteFilter.Monument));
-
+        filterType: siteFilter.Monument
+      )
+    );
+    
     // Add the Hendrix sites achievement
     if (hendrixSites.isNotEmpty) {
-      progressAchievements.add(ProgressAchievement(
+      progressAchievements.add(
+        ProgressAchievement(
           title: "Hendrix Campus Explorer",
           description: "Visit all sites at Hendrix",
-          requiredSites: hendrixSites));
+          requiredSites: hendrixSites
+        )
+      );
     }
   }
 
@@ -135,10 +142,10 @@ class AchievementsPageState extends State<AchievementsPage> {
       );
     }
   }
-
+  
   // Show information popup for progress achievements
-  void showProgressAchievementInfo(BuildContext context,
-      ProgressAchievement achievement, double progress, bool isCompleted) {
+  void showProgressAchievementInfo(
+      BuildContext context, ProgressAchievement achievement, double progress, bool isCompleted) {
     showDialog(
       context: context,
       builder: (context) => Dialog(
@@ -186,8 +193,7 @@ class AchievementsPageState extends State<AchievementsPage> {
 
               // Achievement description
               Padding(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
+                padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
                 child: Text(
                   achievement.description,
                   style: GoogleFonts.rakkas(
@@ -202,8 +208,7 @@ class AchievementsPageState extends State<AchievementsPage> {
 
               // Achievement Status with progress
               Padding(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+                padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
                 child: Column(
                   children: [
                     // Progress bar
@@ -212,8 +217,7 @@ class AchievementsPageState extends State<AchievementsPage> {
                       child: LinearProgressIndicator(
                         value: progress,
                         minHeight: 20,
-                        backgroundColor:
-                            const Color.fromARGB(255, 255, 243, 228),
+                        backgroundColor: const Color.fromARGB(255, 255, 243, 228),
                         color: Colors.green,
                       ),
                     ),
@@ -260,13 +264,8 @@ class AchievementsPageState extends State<AchievementsPage> {
                               child: Row(
                                 children: [
                                   Icon(
-                                    visited
-                                        ? Icons.check_circle
-                                        : Icons.circle_outlined,
-                                    color: visited
-                                        ? Colors.green
-                                        : const Color.fromARGB(
-                                            255, 107, 79, 79),
+                                    visited ? Icons.check_circle : Icons.circle_outlined,
+                                    color: visited ? Colors.green : const Color.fromARGB(255, 107, 79, 79),
                                     size: 20,
                                   ),
                                   const SizedBox(width: 8),
@@ -275,10 +274,7 @@ class AchievementsPageState extends State<AchievementsPage> {
                                       site,
                                       style: GoogleFonts.rakkas(
                                         textStyle: TextStyle(
-                                          color: visited
-                                              ? Colors.green[800]
-                                              : const Color.fromARGB(
-                                                  255, 72, 52, 52),
+                                          color: visited ? Colors.green[800] : const Color.fromARGB(255, 72, 52, 52),
                                           fontSize: 14,
                                         ),
                                       ),
@@ -564,16 +560,18 @@ class AchievementsPageState extends State<AchievementsPage> {
                     ),
                     // List of progress achievements
                     ...progressAchievements.map((achievement) {
-                      double progress =
-                          achievement.calculateProgress(appState.visitedPlaces);
-                      bool isCompleted =
-                          achievement.isCompleted(appState.visitedPlaces);
-
+                      double progress = achievement.calculateProgress(appState.visitedPlaces);
+                      bool isCompleted = achievement.isCompleted(appState.visitedPlaces);
+                      
                       return Padding(
                         padding: const EdgeInsets.only(bottom: 12.0),
                         child: GestureDetector(
                           onTap: () => showProgressAchievementInfo(
-                              context, achievement, progress, isCompleted),
+                            context, 
+                            achievement, 
+                            progress, 
+                            isCompleted
+                          ),
                           child: Container(
                             decoration: BoxDecoration(
                               color: const Color.fromARGB(255, 255, 243, 228),
@@ -598,8 +596,7 @@ class AchievementsPageState extends State<AchievementsPage> {
                               children: [
                                 // Achievement header row
                                 Padding(
-                                  padding:
-                                      const EdgeInsets.fromLTRB(16, 12, 16, 8),
+                                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
                                   child: Row(
                                     children: [
                                       // Achievement icon
@@ -609,25 +606,20 @@ class AchievementsPageState extends State<AchievementsPage> {
                                         decoration: BoxDecoration(
                                           color: isCompleted
                                               ? Colors.green[100]
-                                              : Color.fromARGB(
-                                                  255, 238, 214, 196),
+                                              : Color.fromARGB(255, 238, 214, 196),
                                           shape: BoxShape.circle,
                                           border: Border.all(
                                             color: isCompleted
                                                 ? Colors.green
-                                                : Color.fromARGB(
-                                                    255, 107, 79, 79),
+                                                : Color.fromARGB(255, 107, 79, 79),
                                             width: 2,
                                           ),
                                         ),
                                         child: Icon(
-                                          isCompleted
-                                              ? Icons.emoji_events
-                                              : Icons.stars,
+                                          isCompleted ? Icons.emoji_events : Icons.stars,
                                           color: isCompleted
                                               ? Colors.green
-                                              : Color.fromARGB(
-                                                  255, 107, 79, 79),
+                                              : Color.fromARGB(255, 107, 79, 79),
                                           size: 24,
                                         ),
                                       ),
@@ -635,15 +627,13 @@ class AchievementsPageState extends State<AchievementsPage> {
                                       // Achievement title and description
                                       Expanded(
                                         child: Column(
-                                          crossAxisAlignment:
-                                              CrossAxisAlignment.start,
+                                          crossAxisAlignment: CrossAxisAlignment.start,
                                           children: [
                                             Text(
                                               achievement.title,
                                               style: GoogleFonts.ultra(
                                                 textStyle: TextStyle(
-                                                  color: Color.fromARGB(
-                                                      255, 72, 52, 52),
+                                                  color: Color.fromARGB(255, 72, 52, 52),
                                                   fontSize: 16,
                                                   fontWeight: FontWeight.bold,
                                                 ),
@@ -654,8 +644,7 @@ class AchievementsPageState extends State<AchievementsPage> {
                                               achievement.description,
                                               style: GoogleFonts.rakkas(
                                                 textStyle: TextStyle(
-                                                  color: Color.fromARGB(
-                                                      255, 107, 79, 79),
+                                                  color: Color.fromARGB(255, 107, 79, 79),
                                                   fontSize: 14,
                                                 ),
                                               ),
@@ -670,8 +659,7 @@ class AchievementsPageState extends State<AchievementsPage> {
                                           textStyle: TextStyle(
                                             color: isCompleted
                                                 ? Colors.green[800]
-                                                : Color.fromARGB(
-                                                    255, 72, 52, 52),
+                                                : Color.fromARGB(255, 72, 52, 52),
                                             fontSize: 16,
                                             fontWeight: FontWeight.bold,
                                           ),
@@ -682,15 +670,13 @@ class AchievementsPageState extends State<AchievementsPage> {
                                 ),
                                 // Progress bar
                                 Padding(
-                                  padding:
-                                      const EdgeInsets.fromLTRB(16, 4, 16, 12),
+                                  padding: const EdgeInsets.fromLTRB(16, 4, 16, 12),
                                   child: ClipRRect(
                                     borderRadius: BorderRadius.circular(10),
                                     child: LinearProgressIndicator(
                                       value: progress,
                                       minHeight: 8,
-                                      backgroundColor:
-                                          Color.fromARGB(255, 238, 214, 196),
+                                      backgroundColor: Color.fromARGB(255, 238, 214, 196),
                                       color: Colors.green,
                                     ),
                                   ),
@@ -701,7 +687,7 @@ class AchievementsPageState extends State<AchievementsPage> {
                         ),
                       );
                     }).toList(),
-
+                    
                     // Divider between sections
                     Padding(
                       padding: const EdgeInsets.symmetric(vertical: 16.0),
@@ -711,7 +697,7 @@ class AchievementsPageState extends State<AchievementsPage> {
                       ),
                     ),
                   ],
-
+                  
                   // Individual Historical Sites Achievements
                   Padding(
                     padding: const EdgeInsets.only(bottom: 16.0),
@@ -730,8 +716,7 @@ class AchievementsPageState extends State<AchievementsPage> {
                   GridView.builder(
                     shrinkWrap: true,
                     physics: NeverScrollableScrollPhysics(),
-                    gridDelegate:
-                        const SliverGridDelegateWithFixedCrossAxisCount(
+                    gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
                       crossAxisCount: 3,
                       mainAxisSpacing: 10,
                       crossAxisSpacing: 10,
@@ -794,8 +779,7 @@ class AchievementsPageState extends State<AchievementsPage> {
                                       textAlign: TextAlign.center,
                                       style: TextStyle(
                                         fontWeight: FontWeight.bold,
-                                        fontSize:
-                                            fontSize, // Adaptive font size
+                                        fontSize: fontSize, // Adaptive font size
                                         color: Color.fromARGB(255, 72, 52, 52),
                                       ),
                                       maxLines: 3, // Increased max lines

--- a/faulkner_footsteps/lib/pages/list_page.dart
+++ b/faulkner_footsteps/lib/pages/list_page.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:faulkner_footsteps/app_state.dart';
 import 'package:faulkner_footsteps/dialogs/filter_Dialog.dart';
 import 'package:faulkner_footsteps/objects/hist_site.dart';
-import 'package:faulkner_footsteps/pages/achievement.dart';
 import 'package:faulkner_footsteps/pages/map_display.dart';
 import 'package:faulkner_footsteps/widgets/logout_button.dart';
 import 'package:faulkner_footsteps/widgets/profile_button.dart';
@@ -62,13 +61,6 @@ class _ListPageState extends State<ListPage> {
       print("update loop");
     }
   }
-  //not sure if this code is important, I will leave it in for now
-  // Future<void> showRatingDialog() async {
-  //   await showDialog<double>(
-  //     context: context,
-  //     builder: (BuildContext context) => RatingDialog(widget.app_state, ),
-  //   );
-  // }
 
   late Timer updateTimer;
   late List<HistSite> fullSiteList;
@@ -95,7 +87,6 @@ class _ListPageState extends State<ListPage> {
       siteFilter.Other
     ];
     searchSites = fullSiteList;
-    // print("INIT STATE");
 
     _searchController = SearchController();
     super.initState();
@@ -223,9 +214,6 @@ class _ListPageState extends State<ListPage> {
     );
   }
 
-  //So funny enough, I don't think this is necessary.
-  // I changed the way the site list forms, so i think once you sort them once they are always sorted.
-  // Whoops, i guess we have this if we need it.
   void sortDisplayItems() {
     List<HistSite> lst = [];
     siteLocations = widget.app_state.getLocations();
@@ -234,7 +222,6 @@ class _ListPageState extends State<ListPage> {
       ..sort((e1, e2) => e1.value.compareTo(e2.value)));
     int i = 0;
     while (i < sorted.keys.length) {
-      //TODO: issue with contains. It is looking for a string, not a HistSite!!!
       for (HistSite site in displaySites) {
         if (site.name == sorted.keys.elementAt(i)) {
           lst.add(site);
@@ -242,10 +229,6 @@ class _ListPageState extends State<ListPage> {
           print("sorted name: ${sorted.keys.elementAt(i)}");
         }
       }
-
-      // displaySites.add(fullSiteList.firstWhere((x) {
-      //   return x.name == sorted.keys.elementAt(i);
-      // }));
       i++;
     }
     print("Lst: $lst");
@@ -265,9 +248,6 @@ class _ListPageState extends State<ListPage> {
     }
     searchSites = fullSiteList;
     sortDisplayItems();
-
-    // print("Sorted: $sorted");
-    // print("Display List: $displaySites");
   }
 
   void filterChangedCallback() {
@@ -446,9 +426,7 @@ class _ListPageState extends State<ListPage> {
               child: Text(
                 _selectedIndex == 0
                     ? "Historical Sites"
-                    : _selectedIndex == 1
-                        ? "Map                    "
-                        : "Achievements",
+                    : "Map                    ",
                 style: GoogleFonts.ultra(
                     textStyle: const TextStyle(
                         color: Color.fromARGB(255, 255, 243, 228)),
@@ -458,15 +436,11 @@ class _ListPageState extends State<ListPage> {
           )),
       body: _selectedIndex == 0
           ? _buildHomeContent()
-          : _selectedIndex == 1
-              ? MapDisplay(
-                  currentPosition: _currentPosition!,
-                  initialPosition: _currentPosition!,
-                  appState: widget.app_state,
-                )
-              : AchievementsPage(
-                  displaySites: displaySites,
-                ),
+          : MapDisplay(
+              currentPosition: _currentPosition!,
+              initialPosition: _currentPosition!,
+              appState: widget.app_state,
+            ),
       bottomNavigationBar: BottomNavigationBar(
         backgroundColor: const Color.fromARGB(255, 107, 79, 79),
         selectedItemColor: const Color.fromARGB(255, 238, 214, 196),
@@ -480,25 +454,10 @@ class _ListPageState extends State<ListPage> {
             icon: Icon(Icons.map),
             label: 'Map',
           ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.emoji_events),
-            label: 'Achievements',
-          ),
         ],
         currentIndex: _selectedIndex,
         onTap: _onItemTapped,
       ),
-
-      // Uncomment to add sites
-      /*
-      floatingActionButton: FloatingActionButton(onPressed: () {
-        showDialog(
-            context: context,
-            builder: (_) {
-              return SiteDialogue(siteAdded: widget.app_state.addSite);
-            });
-      }),
-      */
     );
   }
 }

--- a/faulkner_footsteps/lib/pages/profile_page.dart
+++ b/faulkner_footsteps/lib/pages/profile_page.dart
@@ -1,4 +1,5 @@
 import 'package:faulkner_footsteps/app_router.dart';
+import 'package:faulkner_footsteps/pages/achievement.dart';
 import 'package:faulkner_footsteps/pages/admin_page.dart';
 import 'package:faulkner_footsteps/pages/login_page.dart';
 import 'package:flutter/material.dart';
@@ -69,6 +70,19 @@ class _ProfilePageState extends State<ProfilePage> {
         });
       }
     }
+  }
+
+  void _navigateToAchievementsPage() {
+    // Navigate to achievements page with the app state's historical sites
+    final appState = Provider.of<ApplicationState>(context, listen: false);
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => AchievementsPage(
+          displaySites: appState.historicalSites,
+        ),
+      ),
+    );
   }
 
   @override
@@ -221,14 +235,46 @@ class _ProfilePageState extends State<ProfilePage> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(
-                        'My Achievements',
-                        style: GoogleFonts.ultra(
-                          textStyle: const TextStyle(
-                            color: Color.fromARGB(255, 72, 52, 52),
-                            fontSize: 16,
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Text(
+                            'My Achievements',
+                            style: GoogleFonts.ultra(
+                              textStyle: const TextStyle(
+                                color: Color.fromARGB(255, 72, 52, 52),
+                                fontSize: 16,
+                              ),
+                            ),
                           ),
-                        ),
+                          // New achievement button
+                          Container(
+                            width: 40,
+                            height: 40,
+                            decoration: BoxDecoration(
+                              color: Color.fromARGB(255, 107, 79, 79),
+                              borderRadius: BorderRadius.circular(8.0),
+                              border: Border.all(
+                                color: Color.fromARGB(255, 255, 243, 228),
+                                width: 2.0,
+                              ),
+                            ),
+                            child: Material(
+                              color: Colors.transparent,
+                              child: InkWell(
+                                borderRadius: BorderRadius.circular(8.0),
+                                onTap: _navigateToAchievementsPage,
+                                child: Center(
+                                  child: Icon(
+                                    Icons.emoji_events,
+                                    color: Color.fromARGB(255, 255, 243, 228),
+                                    size: 24,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
                       ),
                       const SizedBox(height: 16),
                       Consumer<ApplicationState>(

--- a/faulkner_footsteps/lib/pages/profile_page.dart
+++ b/faulkner_footsteps/lib/pages/profile_page.dart
@@ -7,6 +7,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
 import 'package:faulkner_footsteps/app_state.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class ProfilePage extends StatefulWidget {
   const ProfilePage({super.key});
@@ -15,13 +16,93 @@ class ProfilePage extends StatefulWidget {
   State<ProfilePage> createState() => _ProfilePageState();
 }
 
-class _ProfilePageState extends State<ProfilePage> {
+class _ProfilePageState extends State<ProfilePage> with SingleTickerProviderStateMixin {
   final _formKey = GlobalKey<FormState>();
   final _currentPasswordController = TextEditingController();
   final _newPasswordController = TextEditingController();
   final _confirmPasswordController = TextEditingController();
   bool _isLoading = false;
   String? _errorMessage;
+  
+  // Animation controller for the achievement button
+  late AnimationController _animationController;
+  late Animation<double> _scaleAnimation;
+  late Animation<Color?> _colorAnimation;
+  
+  // Track notification count
+  int newAchievementCount = 0;
+  bool _hasCheckedAchievements = false;
+
+  @override
+  void initState() {
+    super.initState();
+    
+    // Set up animations
+    _animationController = AnimationController(
+      duration: const Duration(milliseconds: 800),
+      vsync: this,
+    );
+    
+    // Create pulsating animation
+    _scaleAnimation = Tween<double>(begin: 1.0, end: 1.1).animate(
+      CurvedAnimation(
+        parent: _animationController,
+        curve: Curves.easeInOut,
+      ),
+    );
+    
+    // Create color animation (glow effect)
+    _colorAnimation = ColorTween(
+      begin: const Color.fromARGB(255, 107, 79, 79),
+      end: const Color.fromARGB(255, 76, 175, 80),
+    ).animate(
+      CurvedAnimation(
+        parent: _animationController,
+        curve: Curves.easeInOut,
+      ),
+    );
+    
+    // Start the animation and make it repeat
+    _animationController.repeat(reverse: true);
+    
+    // Check for notification count
+    _loadAchievementNotificationStatus();
+  }
+  
+  // Load achievement notification status
+  Future<void> _loadAchievementNotificationStatus() async {
+    final prefs = await SharedPreferences.getInstance();
+    final lastAchievementCount = prefs.getInt('last_achievement_count') ?? 0;
+    final hasViewedAchievements = prefs.getBool('has_viewed_achievements') ?? false;
+    
+    // Get current achievements count
+    final appState = Provider.of<ApplicationState>(context, listen: false);
+    final currentCount = appState.visitedPlaces.length;
+    
+    setState(() {
+      _hasCheckedAchievements = hasViewedAchievements;
+      
+      // If user has never viewed achievements or has new ones
+      if (!hasViewedAchievements || currentCount > lastAchievementCount) {
+        newAchievementCount = currentCount - lastAchievementCount;
+        if (!hasViewedAchievements && currentCount == 0) {
+          // For new users who haven't visited any sites
+          newAchievementCount = 1; // Show notification to encourage exploring
+        }
+      } else {
+        newAchievementCount = 0;
+      }
+    });
+  }
+  
+  // Save achievement notification status
+  Future<void> _saveAchievementNotificationStatus() async {
+    final prefs = await SharedPreferences.getInstance();
+    final appState = Provider.of<ApplicationState>(context, listen: false);
+    
+    await prefs.setInt('last_achievement_count', appState.visitedPlaces.length);
+    await prefs.setBool('has_viewed_achievements', true);
+  }
 
   Future<void> _changePassword() async {
     if (!_formKey.currentState!.validate()) return;
@@ -72,7 +153,15 @@ class _ProfilePageState extends State<ProfilePage> {
     }
   }
 
-  void _navigateToAchievementsPage() {
+  void _navigateToAchievementsPage() async {
+    // Reset notification count
+    setState(() {
+      newAchievementCount = 0;
+    });
+    
+    // Save the current achievement count
+    await _saveAchievementNotificationStatus();
+    
     // Navigate to achievements page with the app state's historical sites
     final appState = Provider.of<ApplicationState>(context, listen: false);
     Navigator.push(
@@ -247,32 +336,99 @@ class _ProfilePageState extends State<ProfilePage> {
                               ),
                             ),
                           ),
-                          // New achievement button
-                          Container(
-                            width: 40,
-                            height: 40,
-                            decoration: BoxDecoration(
-                              color: Color.fromARGB(255, 107, 79, 79),
-                              borderRadius: BorderRadius.circular(8.0),
-                              border: Border.all(
-                                color: Color.fromARGB(255, 255, 243, 228),
-                                width: 2.0,
+                          // New achievement button with animation and notification badge
+                          Stack(
+                            clipBehavior: Clip.none, // This prevents clipping of child elements
+                            children: [
+                              // Animated achievement button
+                              AnimatedBuilder(
+                                animation: _animationController,
+                                builder: (context, child) {
+                                  return Transform.scale(
+                                    scale: newAchievementCount > 0 ? _scaleAnimation.value : 1.0,
+                                    child: Container(
+                                      width: 40,
+                                      height: 40,
+                                      decoration: BoxDecoration(
+                                        color: newAchievementCount > 0 
+                                            ? _colorAnimation.value
+                                            : Color.fromARGB(255, 107, 79, 79),
+                                        borderRadius: BorderRadius.circular(8.0),
+                                        border: Border.all(
+                                          color: Color.fromARGB(255, 255, 243, 228),
+                                          width: 2.0,
+                                        ),
+                                        boxShadow: newAchievementCount > 0
+                                            ? [
+                                                BoxShadow(
+                                                  color: Colors.green.withOpacity(0.3),
+                                                  spreadRadius: 1,
+                                                  blurRadius: 6,
+                                                  offset: Offset(0, 0),
+                                                )
+                                              ]
+                                            : null,
+                                      ),
+                                      child: Material(
+                                        color: Colors.transparent,
+                                        child: InkWell(
+                                          borderRadius: BorderRadius.circular(8.0),
+                                          onTap: _navigateToAchievementsPage,
+                                          child: Center(
+                                            child: Icon(
+                                              Icons.emoji_events,
+                                              color: Color.fromARGB(255, 255, 243, 228),
+                                              size: 24,
+                                            ),
+                                          ),
+                                        ),
+                                      ),
+                                    ),
+                                  );
+                                },
                               ),
-                            ),
-                            child: Material(
-                              color: Colors.transparent,
-                              child: InkWell(
-                                borderRadius: BorderRadius.circular(8.0),
-                                onTap: _navigateToAchievementsPage,
-                                child: Center(
-                                  child: Icon(
-                                    Icons.emoji_events,
-                                    color: Color.fromARGB(255, 255, 243, 228),
-                                    size: 24,
+                              
+                              // Notification badge with adjusted position
+                              if (newAchievementCount > 0)
+                                Positioned(
+                                  top: -8,
+                                  right: -8,
+                                  child: Container(
+                                    padding: EdgeInsets.all(4),
+                                    decoration: BoxDecoration(
+                                      color: Colors.red,
+                                      shape: BoxShape.circle,
+                                      border: Border.all(
+                                        color: Color.fromARGB(255, 255, 243, 228),
+                                        width: 1.5,
+                                      ),
+                                      // Add a bit of margin to ensure visibility
+                                      boxShadow: [
+                                        BoxShadow(
+                                          color: Colors.black.withOpacity(0.2),
+                                          spreadRadius: 1,
+                                          blurRadius: 2,
+                                          offset: Offset(0, 1),
+                                        ),
+                                      ],
+                                    ),
+                                    constraints: BoxConstraints(
+                                      minWidth: 18,
+                                      minHeight: 18,
+                                    ),
+                                    child: Center(
+                                      child: Text(
+                                        newAchievementCount.toString(),
+                                        style: TextStyle(
+                                          color: Colors.white,
+                                          fontSize: 10,
+                                          fontWeight: FontWeight.bold,
+                                        ),
+                                      ),
+                                    ),
                                   ),
                                 ),
-                              ),
-                            ),
+                            ],
                           ),
                         ],
                       ),
@@ -586,6 +742,7 @@ class _ProfilePageState extends State<ProfilePage> {
     _currentPasswordController.dispose();
     _newPasswordController.dispose();
     _confirmPasswordController.dispose();
+    _animationController.dispose();
     super.dispose();
   }
 }

--- a/faulkner_footsteps/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/faulkner_footsteps/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -14,6 +14,7 @@ import firebase_core
 import firebase_storage
 import geolocator_apple
 import path_provider_foundation
+import shared_preferences_foundation
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
@@ -26,5 +27,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseStoragePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseStoragePlugin"))
   GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/faulkner_footsteps/pubspec.lock
+++ b/faulkner_footsteps/pubspec.lock
@@ -845,6 +845,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.2"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.3"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "9f9f3d372d4304723e6136663bb291c0b93f5e4c8a4a6314347f481a33bda2b1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.7"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "6a52cfcdaeac77cad8c97b539ff688ccfc458c007b4db12be584fbe5c0e49e03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/faulkner_footsteps/pubspec.yaml
+++ b/faulkner_footsteps/pubspec.yaml
@@ -57,6 +57,7 @@ dependencies:
   image_picker: ^1.1.2
   firebase_storage: ^12.4.4
   uuid: ^4.5.1
+  shared_preferences: ^2.5.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Closes #86 

MASSIVE overhaul on achievements. Achievements page is no longer at the bottom nav bar when you start the app. Instead it has been moved over to the profile page, where first time users and users that have gotten an achievement for visiting a site will be greeted by a flashing button next their their "Achievements" section of the profile page. On the new and improved achievements page users are able to tap on achievements and be greeted by a popup that tells them what they need to do to achieve an achievement or the specific locations they must visit in order to get a long term achievement. Likewise, if a user has visited a location and gotten the achievement then they are greeted by pop-up that gives them a congratulations when clicking on an achievement they have earned. Finally, achievement page and new long-term achievements that require multiple locations to achieve all fit in the app with theme and color scheme. 
