### PR TITLE
Editing, Adding, Deleting Sites Syncs to List Page, Filter Chip Duplication Issue Fixed

### DIFF
--- a/faulkner_footsteps/lib/app_state.dart
+++ b/faulkner_footsteps/lib/app_state.dart
@@ -210,6 +210,8 @@ class ApplicationState extends ChangeNotifier {
         .collection("sites")
         .doc(newSite.name)
         .collection("ratings");
+
+    notifyListeners();
   }
 
   Future<double> getUserRating(String siteName) async {

--- a/faulkner_footsteps/lib/pages/admin_page.dart
+++ b/faulkner_footsteps/lib/pages/admin_page.dart
@@ -45,6 +45,14 @@ class _AdminListPageState extends State<AdminListPage> {
     // acceptableFilters.addAll(siteFilter.values);
     // acceptableFilters.remove(siteFilter.Other);
     acceptableFilters = widget.app_state.siteFilters;
+
+    widget.app_state.addListener(() {
+      print("Appstate has changed!");
+      setState(() {
+        acceptableFilters =
+            widget.app_state.siteFilters; // Might be necessary, idk really
+      });
+    });
   }
 
   void _update(Timer timer) {

--- a/faulkner_footsteps/lib/pages/admin_page.dart
+++ b/faulkner_footsteps/lib/pages/admin_page.dart
@@ -769,6 +769,9 @@ class _AdminListPageState extends State<AdminListPage> {
                   onPressed: () => Navigator.pop(context),
                   child: const Text('Cancel'),
                 ),
+
+// beginning of submit button ------------------------------
+
                 ElevatedButton(
                   style: ElevatedButton.styleFrom(
                     backgroundColor: const Color.fromARGB(255, 218, 186, 130),

--- a/faulkner_footsteps/lib/pages/list_page.dart
+++ b/faulkner_footsteps/lib/pages/list_page.dart
@@ -494,7 +494,7 @@ class _ListPageState extends State<ListPage> {
             child: FittedBox(
               child: Text(
                 _selectedIndex == 0
-                    ? "Historical Sites V1"
+                    ? "Historical Sites"
                     : "Map                    ",
                 style: GoogleFonts.ultra(
                     textStyle: const TextStyle(

--- a/faulkner_footsteps/lib/pages/list_page.dart
+++ b/faulkner_footsteps/lib/pages/list_page.dart
@@ -260,17 +260,22 @@ class _ListPageState extends State<ListPage> {
 
   void setDisplayItems() {
     fullSiteList = widget.app_state.historicalSites;
-    bool shouldAdd = true;
-    for (HistSite site in fullSiteList) {
-      for (HistSite tst in displaySites) {
-        if (tst.name == site.name) {
-          shouldAdd = false;
-          break;
-        }
-      }
-      if (shouldAdd) displaySites.add(site);
-      shouldAdd = true;
-    }
+    displaySites.clear();
+    displaySites.addAll(fullSiteList);
+    // This results in edits not taking place
+
+    // bool shouldAdd = true;
+    // for (HistSite site in fullSiteList) {
+    //   for (HistSite tst in displaySites) {
+    //     if (tst.name == site.name) {
+    //       shouldAdd = false;
+    //       break;
+    //     }
+    //   }
+    //   if (shouldAdd) displaySites.add(site);
+    //   shouldAdd = true;
+    // }
+
     setState(() {});
     // print("Full Site List: $fullSiteList");
     // print("Display Sites: $displaySites");

--- a/faulkner_footsteps/lib/pages/list_page.dart
+++ b/faulkner_footsteps/lib/pages/list_page.dart
@@ -92,7 +92,9 @@ class _ListPageState extends State<ListPage> {
 
     widget.app_state.addListener(() {
       print("historical sites list has changed!!!");
-      setState(() {});
+      setState(() {
+        setDisplayItems();
+      });
     });
     super.initState();
   }
@@ -257,17 +259,25 @@ class _ListPageState extends State<ListPage> {
   }
 
   void setDisplayItems() {
-    if (fullSiteList.isEmpty) {
-      fullSiteList = widget.app_state.historicalSites;
-      displaySites.addAll(fullSiteList);
-
-      // print("Full Site List: $fullSiteList");
-      // print("Display Sites: $displaySites");
-      print("setDisplayItems is called");
-      activeFilters.clear();
-      activeFilters.addAll(widget.app_state.siteFilters);
-      // print("ALL active filters: $activeFilters");
+    fullSiteList = widget.app_state.historicalSites;
+    bool shouldAdd = true;
+    for (HistSite site in fullSiteList) {
+      for (HistSite tst in displaySites) {
+        if (tst.name == site.name) {
+          shouldAdd = false;
+          break;
+        }
+      }
+      if (shouldAdd) displaySites.add(site);
+      shouldAdd = true;
     }
+    setState(() {});
+    // print("Full Site List: $fullSiteList");
+    // print("Display Sites: $displaySites");
+    print("setDisplayItems is called");
+    activeFilters.clear();
+    activeFilters.addAll(widget.app_state.siteFilters);
+    // print("ALL active filters: $activeFilters");
     /*
       I want to put the other filter last, so I remove it from th e
     */
@@ -462,7 +472,7 @@ class _ListPageState extends State<ListPage> {
         child: CircularProgressIndicator(),
       );
     }
-    setDisplayItems(); //this is here so that it loads initially. Otherwise nothing loads.
+    //setDisplayItems(); //this is here so that it loads initially. Otherwise nothing loads.
     return Scaffold(
       backgroundColor: const Color.fromARGB(255, 238, 214, 196),
       appBar: AppBar(
@@ -484,7 +494,7 @@ class _ListPageState extends State<ListPage> {
             child: FittedBox(
               child: Text(
                 _selectedIndex == 0
-                    ? "Historical Sites"
+                    ? "Historical Sites V1"
                     : "Map                    ",
                 style: GoogleFonts.ultra(
                     textStyle: const TextStyle(

--- a/faulkner_footsteps/lib/pages/list_page.dart
+++ b/faulkner_footsteps/lib/pages/list_page.dart
@@ -83,15 +83,22 @@ class _ListPageState extends State<ListPage> {
     updateTimer = Timer.periodic(const Duration(milliseconds: 1000), _update);
     displaySites = widget.app_state.historicalSites;
     fullSiteList = widget.app_state.historicalSites;
+
     // activeFilters.addAll(widget.app_state
     // .siteFilters); //I suspect that this doesn't load quickly enough and that is why active filters starts empty
     searchSites = fullSiteList;
 
     _searchController = SearchController();
+
+    widget.app_state.addListener(() {
+      print("historical sites list has changed!!!");
+      setState(() {});
+    });
     super.initState();
   }
 
 //TODO: See if this helps... in my testing i thought it just made like 3x as many filters... might not be ideal.
+//TODO: Also, maybe change the filterchips to be a set so duplicates are removed? That might be an easy solution to that issue
   // void didChangeDependencies() {
   //   super.didChangeDependencies();
   //   final appState = Provider.of<ApplicationState>(context);
@@ -119,6 +126,7 @@ class _ListPageState extends State<ListPage> {
 
   @override
   void dispose() {
+    widget.app_state.dispose();
     super.dispose();
     updateTimer.cancel();
   }
@@ -255,6 +263,8 @@ class _ListPageState extends State<ListPage> {
 
       // print("Full Site List: $fullSiteList");
       // print("Display Sites: $displaySites");
+      print("setDisplayItems is called");
+      activeFilters.clear();
       activeFilters.addAll(widget.app_state.siteFilters);
       // print("ALL active filters: $activeFilters");
     }


### PR DESCRIPTION
closes #106 
closes #111 
closes #118

Basically what title says. Admin page syncs to list page now. I added a listener that triggers the historical sites to reload when the notifylisteners() is called in appstate. 
Filter chip duplication issue is fixed. Apparently if you try to populate the active filters list in the build method, the build method could get called multiple times resulting in filters being added twice. I now clear filters before I populate them and moved the method out of the build method and now triggers when the listener is triggered. 